### PR TITLE
Add back accidentally lost flatpak_get_kernel_arch

### DIFF
--- a/src/builder-flatpak-utils.c
+++ b/src/builder-flatpak-utils.c
@@ -201,6 +201,55 @@ flatpak_path_match_prefix (const char *pattern,
   return NULL; /* Should not be reached */
 }
 
+static const char *
+flatpak_get_kernel_arch (void)
+{
+  static struct utsname buf;
+  static char *arch = NULL;
+  char *m;
+
+  if (arch != NULL)
+    return arch;
+
+  if (uname (&buf))
+    {
+      arch = "unknown";
+      return arch;
+    }
+
+  /* By default, just pass on machine, good enough for most arches */
+  arch = buf.machine;
+
+  /* Override for some arches */
+
+  m = buf.machine;
+  /* i?86 */
+  if (strlen (m) == 4 && m[0] == 'i' && m[2] == '8'  && m[3] == '6')
+    {
+      arch = "i386";
+    }
+  else if (g_str_has_prefix (m, "arm"))
+    {
+      if (g_str_has_suffix (m, "b"))
+        arch = "armeb";
+      else
+        arch = "arm";
+    }
+  else if (strcmp (m, "mips") == 0)
+    {
+#if G_BYTE_ORDER == G_LITTLE_ENDIAN
+      arch = "mipsel";
+#endif
+    }
+  else if (strcmp (m, "mips64") == 0)
+    {
+#if G_BYTE_ORDER == G_LITTLE_ENDIAN
+      arch = "mips64el";
+#endif
+    }
+
+  return arch;
+}
 
 /* This maps the kernel-reported uname to a single string representing
  * the cpu family, in the sense that all members of this family would


### PR DESCRIPTION
I was putting together a Fedora flatpak-builder package and ran into undefined flatpak_get_kernel_arch() on ppc64le. It's guarded by ifdefs which is why the build didn't break on x86_64. This adds back the accidentally lost function.