### PR TITLE
Add missing documentation

### DIFF
--- a/doc/flatpak-builder.xml
+++ b/doc/flatpak-builder.xml
@@ -238,7 +238,13 @@
 
                 <listitem><para>
                   List all the (local) files that the manifest depends on.
-                </para></listitem>
+                  </para>
+
+                  <para>
+                  Only the <option>--verbose</option> option can be combined
+                  with this option.
+                  </para>
+                </listitem>
             </varlistentry>
 
             <varlistentry>

--- a/doc/flatpak-builder.xml
+++ b/doc/flatpak-builder.xml
@@ -211,7 +211,16 @@
                   arguments to give the same environment as the build, and the same permissions the final app
                   will have. The command to run must be the last argument passed to
                   flatpak-builder, after the directory and the manifest.
-                </para></listitem>
+                  </para>
+
+                  <para>
+                  Only the
+                  <option>--arch=</option><replaceable>ARCH</replaceable>,
+                  <option>--ccache</option> and
+                  <option>--verbose</option> options can be combined
+                  with this option.
+                  </para>
+                </listitem>
             </varlistentry>
 
             <varlistentry>

--- a/doc/flatpak-builder.xml
+++ b/doc/flatpak-builder.xml
@@ -158,6 +158,17 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--default-branch=<replaceable>BRANCH</replaceable></option></term>
+
+                <listitem><para>
+                    Set the default branch to
+                    <replaceable>BRANCH</replaceable>. This is used if
+                    the manifest does not specify a branch. The default
+                    is <literal>master</literal>.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--disable-cache</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-builder.xml
+++ b/doc/flatpak-builder.xml
@@ -241,6 +241,18 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--bundle-sources</option></term>
+
+                <listitem><para>
+                    Create an additional runtime with the source code for
+                    this module. It will be named
+                    <replaceable>app-id</replaceable><literal>.Sources</literal>,
+                    for example
+                    <literal>org.gnome.Maps.Sources</literal>.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--build-only</option></term>
 
                 <listitem><para>


### PR DESCRIPTION
`--default-branch` and `--bundle-sources` weren't documented.

Additionally, `--run` and `--show-deps` take a restricted set of options, which wasn't documented either.