### PR TITLE
add the missing '[]' around AC_MSG_ERROR

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,7 +43,7 @@ if test "x$FLATPAK" = xfalse; then
 else
    FLATPAK_VERSION=`$FLATPAK --version | sed 's,.*\ \([0-9]*\.[0-9]*\.[0-9]*\)$,\1,'`
    AX_COMPARE_VERSION([$FLATPAK_REQS],[gt],[$FLATPAK_VERSION],
-         AC_MSG_ERROR([You need at least version $FLATPAK_REQS of flatpak, your version is $FLATPAK_VERSION]))
+                      [AC_MSG_ERROR([You need at least version $FLATPAK_REQS of flatpak, your version is $FLATPAK_VERSION])])
 fi
 
 
@@ -90,8 +90,8 @@ AX_VALGRIND_CHECK
 PKG_PROG_PKG_CONFIG([0.24])
 
 AC_CHECK_FUNCS(fdwalk)
-AC_CHECK_HEADER([sys/xattr.h], [], AC_MSG_ERROR([You must have sys/xattr.h from glibc]))
-AC_CHECK_HEADER([sys/capability.h], have_caps=yes, AC_MSG_ERROR([sys/capability.h header not found]))
+AC_CHECK_HEADER([sys/xattr.h], [], [AC_MSG_ERROR([You must have sys/xattr.h from glibc])])
+AC_CHECK_HEADER([sys/capability.h], have_caps=yes, [AC_MSG_ERROR([sys/capability.h header not found])])
 
 PKG_CHECK_MODULES(BASE, [glib-2.0 >= $GLIB_REQS gio-2.0 gio-unix-2.0 libsoup-2.4 ostree-1 >= $OSTREE_REQS json-glib-1.0])
 


### PR DESCRIPTION
Without the '[]', if the error sentence contains a comma(just as the line 46), it will cause strange output or error, such as:
configure: error: You need at least version 0.9.13 of flatpak
    else your version is Flatpak 0.9.7
or other syntax error.