### PR TITLE
Add extra-data sources

### DIFF
--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -640,6 +640,35 @@
                     </varlistentry>
                 </variablelist>
             </refsect3>
+            <refsect3>
+                <title>Extra data sources</title>
+                <variablelist>
+                    <varlistentry>
+                        <term><option>type</option></term>
+                        <listitem><para>"extra-data"</para></listitem>
+                    </varlistentry>
+                    <varlistentry>
+                        <term><option>filename</option> (string)</term>
+                        <listitem><para>The name to use for the downloaded extra data</para></listitem>
+                    </varlistentry>
+                    <varlistentry>
+                        <term><option>url</option> (string)</term>
+                        <listitem><para>The url to the extra data.</para></listitem>
+                    </varlistentry>
+                    <varlistentry>
+                        <term><option>sha256</option> (string)</term>
+                        <listitem><para>The sha256 of the extra data.</para></listitem>
+                    </varlistentry>
+                    <varlistentry>
+                        <term><option>size</option> (string)</term>
+                        <listitem><para>The size of the extra data.</para></listitem>
+                    </varlistentry>
+                    <varlistentry>
+                        <term><option>installed-size</option> (string)</term>
+                        <listitem><para>The extra installed size this adds to the app (optional).</para></listitem>
+                    </varlistentry>
+                </variablelist>
+            </refsect3>
         </refsect2>
     </refsect1>
 

--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -28,6 +28,8 @@ flatpak_builder_SOURCES = \
 	src/builder-source-script.h \
 	src/builder-source-shell.c \
 	src/builder-source-shell.h \
+	src/builder-source-extra-data.c \
+	src/builder-source-extra-data.h \
 	src/builder-source-patch.c \
 	src/builder-source-patch.h \
 	src/builder-context.c \

--- a/src/builder-cache.c
+++ b/src/builder-cache.c
@@ -1238,6 +1238,24 @@ builder_cache_checksum_uint32 (BuilderCache *self,
 }
 
 void
+builder_cache_checksum_uint64 (BuilderCache *self,
+                               guint64       val)
+{
+  guchar v[8];
+
+  v[0] = (val >> 0) & 0xff;
+  v[1] = (val >> 8) & 0xff;
+  v[2] = (val >> 16) & 0xff;
+  v[3] = (val >> 24) & 0xff;
+  v[4] = (val >> 32) & 0xff;
+  v[5] = (val >> 40) & 0xff;
+  v[6] = (val >> 48) & 0xff;
+  v[7] = (val >> 56) & 0xff;
+
+  g_checksum_update (self->checksum, v, 8);
+}
+
+void
 builder_cache_checksum_data (BuilderCache *self,
                              guint8       *data,
                              gsize         len)

--- a/src/builder-cache.h
+++ b/src/builder-cache.h
@@ -75,6 +75,8 @@ void builder_cache_checksum_compat_boolean (BuilderCache *self,
                                             gboolean      val);
 void builder_cache_checksum_uint32 (BuilderCache *self,
                                     guint32       val);
+void builder_cache_checksum_uint64 (BuilderCache *self,
+                                    guint64       val);
 void builder_cache_checksum_data (BuilderCache *self,
                                   guint8       *data,
                                   gsize         len);

--- a/src/builder-manifest.c
+++ b/src/builder-manifest.c
@@ -2493,6 +2493,12 @@ builder_manifest_finish (BuilderManifest *self,
       for (l = self->add_extensions; l != NULL; l = l->next)
         builder_extension_add_finish_args (l->data, args);
 
+      for (l = self->expanded_modules; l != NULL; l = l->next)
+        {
+          BuilderModule *m = l->data;
+          builder_module_finish_sources (m, args, context);
+        }
+
       g_ptr_array_add (args, g_file_get_path (app_dir));
       g_ptr_array_add (args, NULL);
 

--- a/src/builder-module.c
+++ b/src/builder-module.c
@@ -937,6 +937,24 @@ builder_module_extract_sources (BuilderModule  *self,
   return TRUE;
 }
 
+void
+builder_module_finish_sources (BuilderModule  *self,
+                               GPtrArray      *args,
+                               BuilderContext *context)
+{
+  GList *l;
+
+  for (l = self->sources; l != NULL; l = l->next)
+    {
+      BuilderSource *source = l->data;
+
+      if (!builder_source_is_enabled (source, context))
+        continue;
+
+      builder_source_finish (source, args, context);
+    }
+}
+
 gboolean
 builder_module_bundle_sources (BuilderModule  *self,
                                BuilderContext *context,

--- a/src/builder-module.h
+++ b/src/builder-module.h
@@ -68,6 +68,9 @@ gboolean builder_module_extract_sources (BuilderModule  *self,
 gboolean builder_module_bundle_sources (BuilderModule  *self,
                                         BuilderContext *context,
                                         GError        **error);
+void     builder_module_finish_sources (BuilderModule  *self,
+                                        GPtrArray      *args,
+                                        BuilderContext *context);
 gboolean builder_module_ensure_writable (BuilderModule  *self,
                                          BuilderCache   *cache,
                                          BuilderContext *context,

--- a/src/builder-source-extra-data.c
+++ b/src/builder-source-extra-data.c
@@ -1,0 +1,285 @@
+/* builder-source-extra_data.c
+ *
+ * Copyright (C) 2015 Red Hat, Inc
+ *
+ * This file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Alexander Larsson <alexl@redhat.com>
+ */
+
+#include "config.h"
+
+#include <string.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/statfs.h>
+
+#include "builder-flatpak-utils.h"
+#include "builder-utils.h"
+#include "builder-source-extra-data.h"
+
+struct BuilderSourceExtraData
+{
+  BuilderSource parent;
+
+  char         *filename;
+  char         *url;
+  char         *sha256;
+  guint64       size;
+  guint64       installed_size;
+};
+
+typedef struct
+{
+  BuilderSourceClass parent_class;
+} BuilderSourceExtraDataClass;
+
+G_DEFINE_TYPE (BuilderSourceExtraData, builder_source_extra_data, BUILDER_TYPE_SOURCE);
+
+enum {
+  PROP_0,
+  PROP_FILENAME,
+  PROP_URL,
+  PROP_SHA256,
+  PROP_SIZE,
+  PROP_INSTALLED_SIZE,
+  LAST_PROP
+};
+
+static void
+builder_source_extra_data_finalize (GObject *object)
+{
+  BuilderSourceExtraData *self = (BuilderSourceExtraData *) object;
+
+  g_free (self->filename);
+  g_free (self->url);
+  g_free (self->sha256);
+
+  G_OBJECT_CLASS (builder_source_extra_data_parent_class)->finalize (object);
+}
+
+static void
+builder_source_extra_data_get_property (GObject    *object,
+                                        guint       prop_id,
+                                        GValue     *value,
+                                        GParamSpec *pspec)
+{
+  BuilderSourceExtraData *self = BUILDER_SOURCE_EXTRA_DATA (object);
+
+  switch (prop_id)
+    {
+    case PROP_FILENAME:
+      g_value_set_string (value, self->filename);
+      break;
+
+    case PROP_URL:
+      g_value_set_string (value, self->url);
+      break;
+
+    case PROP_SHA256:
+      g_value_set_string (value, self->sha256);
+      break;
+
+    case PROP_SIZE:
+      g_value_set_uint64 (value, self->size);
+      break;
+
+    case PROP_INSTALLED_SIZE:
+      g_value_set_uint64 (value, self->installed_size);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+builder_source_extra_data_set_property (GObject      *object,
+                                        guint         prop_id,
+                                        const GValue *value,
+                                        GParamSpec   *pspec)
+{
+  BuilderSourceExtraData *self = BUILDER_SOURCE_EXTRA_DATA (object);
+
+  switch (prop_id)
+    {
+    case PROP_FILENAME:
+      g_free (self->filename);
+      self->filename = g_value_dup_string (value);
+      break;
+
+    case PROP_URL:
+      g_free (self->url);
+      self->url = g_value_dup_string (value);
+      break;
+
+    case PROP_SHA256:
+      g_free (self->sha256);
+      self->sha256 = g_value_dup_string (value);
+      break;
+
+    case PROP_SIZE:
+      self->size = g_value_get_uint64 (value);
+      break;
+
+    case PROP_INSTALLED_SIZE:
+      self->installed_size = g_value_get_uint64 (value);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static gboolean
+builder_source_extra_data_download (BuilderSource  *source,
+                                    gboolean        update_vcs,
+                                    BuilderContext *context,
+                                    GError        **error)
+{
+  BuilderSourceExtraData *self = BUILDER_SOURCE_EXTRA_DATA (source);
+
+  if (self->filename == NULL)
+    return flatpak_fail (error, "No filename specified for extra data source");
+
+  if (self->url == NULL)
+    return flatpak_fail (error, "No url specified for extra data source");
+
+  if (self->sha256 == NULL)
+    return flatpak_fail (error, "No sha256 specified for extra data source");
+
+  if (self->size == 0)
+    return flatpak_fail (error, "No size specified for extra data source");
+
+  return TRUE;
+}
+
+
+static gboolean
+builder_source_extra_data_extract (BuilderSource  *source,
+                                   GFile          *dest,
+                                   BuilderOptions *build_options,
+                                   BuilderContext *context,
+                                   GError        **error)
+{
+  return TRUE;
+}
+
+static gboolean
+builder_source_extra_data_bundle (BuilderSource  *source,
+                                  BuilderContext *context,
+                                  GError        **error)
+{
+  return TRUE;
+}
+
+static void
+builder_source_extra_data_checksum (BuilderSource  *source,
+                                    BuilderCache   *cache,
+                                    BuilderContext *context)
+{
+  BuilderSourceExtraData *self = BUILDER_SOURCE_EXTRA_DATA (source);
+
+  builder_cache_checksum_str (cache, self->filename);
+  builder_cache_checksum_str (cache, self->url);
+  builder_cache_checksum_str (cache, self->sha256);
+  builder_cache_checksum_uint64 (cache, self->size);
+  builder_cache_checksum_uint64 (cache, self->installed_size);
+}
+
+static void
+builder_source_extra_data_finish (BuilderSource  *source,
+                                  GPtrArray      *args,
+                                  BuilderContext *context)
+{
+  BuilderSourceExtraData *self = BUILDER_SOURCE_EXTRA_DATA (source);
+  char *arg;
+  g_autofree char *installed_size = NULL;
+
+  if (self->installed_size != 0)
+    installed_size = g_strdup_printf ("%" G_GUINT64_FORMAT, self->installed_size);
+  else
+    installed_size = g_strdup ("");
+
+  arg = g_strdup_printf ("--extra-data=%s:%s:%"G_GUINT64_FORMAT":%s:%s",
+                         self->filename,
+                         self->sha256,
+                         self->size,
+                         installed_size,
+                         self->url);
+
+  g_ptr_array_add (args, arg);
+}
+
+static void
+builder_source_extra_data_class_init (BuilderSourceExtraDataClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  BuilderSourceClass *source_class = BUILDER_SOURCE_CLASS (klass);
+
+  object_class->finalize = builder_source_extra_data_finalize;
+  object_class->get_property = builder_source_extra_data_get_property;
+  object_class->set_property = builder_source_extra_data_set_property;
+
+  source_class->download = builder_source_extra_data_download;
+  source_class->extract = builder_source_extra_data_extract;
+  source_class->bundle = builder_source_extra_data_bundle;
+  source_class->checksum = builder_source_extra_data_checksum;
+  source_class->finish = builder_source_extra_data_finish;
+
+  g_object_class_install_property (object_class,
+                                   PROP_URL,
+                                   g_param_spec_string ("url",
+                                                        "",
+                                                        "",
+                                                        NULL,
+                                                        G_PARAM_READWRITE));
+  g_object_class_install_property (object_class,
+                                   PROP_FILENAME,
+                                   g_param_spec_string ("filename",
+                                                        "",
+                                                        "",
+                                                        NULL,
+                                                        G_PARAM_READWRITE));
+  g_object_class_install_property (object_class,
+                                   PROP_SHA256,
+                                   g_param_spec_string ("sha256",
+                                                        "",
+                                                        "",
+                                                        NULL,
+                                                        G_PARAM_READWRITE));
+  g_object_class_install_property (object_class,
+                                   PROP_SIZE,
+                                   g_param_spec_uint64 ("size",
+                                                        "",
+                                                        "",
+                                                        0, G_MAXUINT64,
+                                                        0,
+                                                        G_PARAM_READWRITE));
+  g_object_class_install_property (object_class,
+                                   PROP_INSTALLED_SIZE,
+                                   g_param_spec_uint64 ("installed-size",
+                                                        "",
+                                                        "",
+                                                        0, G_MAXUINT64,
+                                                        0,
+                                                        G_PARAM_READWRITE));
+}
+
+static void
+builder_source_extra_data_init (BuilderSourceExtraData *self)
+{
+}

--- a/src/builder-source-extra-data.h
+++ b/src/builder-source-extra-data.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Alexander Larsson <alexl@redhat.com>
+ */
+
+#ifndef __BUILDER_SOURCE_EXTRA_DATA_H__
+#define __BUILDER_SOURCE_EXTRA_DATA_H__
+
+#include "builder-source.h"
+
+G_BEGIN_DECLS
+
+typedef struct BuilderSourceExtraData BuilderSourceExtraData;
+
+#define BUILDER_TYPE_SOURCE_EXTRA_DATA (builder_source_extra_data_get_type ())
+#define BUILDER_SOURCE_EXTRA_DATA(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), BUILDER_TYPE_SOURCE_EXTRA_DATA, BuilderSourceExtraData))
+#define BUILDER_IS_SOURCE_EXTRA_DATA(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), BUILDER_TYPE_SOURCE_EXTRA_DATA))
+
+GType builder_source_extra_data_get_type (void);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (BuilderSourceExtraData, g_object_unref)
+
+G_END_DECLS
+
+#endif /* __BUILDER_SOURCE_EXTRA_DATA_H__ */

--- a/src/builder-source.c
+++ b/src/builder-source.c
@@ -36,6 +36,7 @@
 #include "builder-source-file.h"
 #include "builder-source-script.h"
 #include "builder-source-shell.h"
+#include "builder-source-extra-data.h"
 
 static void serializable_iface_init (JsonSerializableIface *serializable_iface);
 
@@ -252,6 +253,8 @@ builder_source_to_json (BuilderSource *self)
     type = "script";
   else if (BUILDER_IS_SOURCE_SHELL (self))
     type = "shell";
+  else if (BUILDER_IS_SOURCE_EXTRA_DATA (self))
+    type = "extra-data";
   else if (BUILDER_IS_SOURCE_PATCH (self))
     type = "patch";
   else if (BUILDER_IS_SOURCE_GIT (self))
@@ -285,6 +288,8 @@ builder_source_from_json (JsonNode *node)
     return (BuilderSource *) json_gobject_deserialize (BUILDER_TYPE_SOURCE_SCRIPT, node);
   else if (strcmp (type, "shell") == 0)
     return (BuilderSource *) json_gobject_deserialize (BUILDER_TYPE_SOURCE_SHELL, node);
+  else if (strcmp (type, "extra-data") == 0)
+    return (BuilderSource *) json_gobject_deserialize (BUILDER_TYPE_SOURCE_EXTRA_DATA, node);
   else if (strcmp (type, "patch") == 0)
     return (BuilderSource *) json_gobject_deserialize (BUILDER_TYPE_SOURCE_PATCH, node);
   else if (strcmp (type, "git") == 0)
@@ -386,6 +391,17 @@ builder_source_checksum (BuilderSource  *self,
   builder_cache_checksum_strv (cache, self->skip_arches);
 
   class->checksum (self, cache, context);
+}
+
+void
+builder_source_finish (BuilderSource  *self,
+                       GPtrArray      *args,
+                       BuilderContext *context)
+{
+  BuilderSourceClass *class = BUILDER_SOURCE_GET_CLASS (self);
+
+  if (class->finish)
+    class->finish (self, args, context);
 }
 
 gboolean

--- a/src/builder-source.h
+++ b/src/builder-source.h
@@ -71,6 +71,9 @@ typedef struct
   void (* checksum)(BuilderSource  *self,
                     BuilderCache   *cache,
                     BuilderContext *context);
+  void (* finish)(BuilderSource  *self,
+                  GPtrArray      *args,
+                  BuilderContext *context);
 } BuilderSourceClass;
 
 GType builder_source_get_type (void);
@@ -103,6 +106,9 @@ gboolean builder_source_update (BuilderSource  *self,
 void     builder_source_checksum (BuilderSource  *self,
                                   BuilderCache   *cache,
                                   BuilderContext *context);
+void     builder_source_finish (BuilderSource  *self,
+                                GPtrArray      *args,
+                                BuilderContext *context);
 
 gboolean builder_source_is_enabled (BuilderSource *self,
                                     BuilderContext *context);


### PR DESCRIPTION
All this does is construct a finish arg, but it makes it a lot nicer to create extra-data using manifest. Additionally, it allows you to create per-arch extra data if you set only-arches on the source.

