### PR TITLE
Add appdata-license field

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -93,7 +93,7 @@ AC_CHECK_FUNCS(fdwalk)
 AC_CHECK_HEADER([sys/xattr.h], [], [AC_MSG_ERROR([You must have sys/xattr.h from glibc])])
 AC_CHECK_HEADER([sys/capability.h], have_caps=yes, [AC_MSG_ERROR([sys/capability.h header not found])])
 
-PKG_CHECK_MODULES(BASE, [glib-2.0 >= $GLIB_REQS gio-2.0 gio-unix-2.0 libsoup-2.4 ostree-1 >= $OSTREE_REQS json-glib-1.0])
+PKG_CHECK_MODULES(BASE, [glib-2.0 >= $GLIB_REQS gio-2.0 gio-unix-2.0 libsoup-2.4 ostree-1 >= $OSTREE_REQS json-glib-1.0 libxml-2.0 >= 2.4])
 
 dnl ************************
 dnl *** check for libelf ***

--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -208,6 +208,15 @@
                     <listitem><para>Any icon with this name will be renamed to a name based on id during the cleanup phase. Note that this is the icon name, not the full filenames, so it should not include a filename extension. </para></listitem>
                 </varlistentry>
                 <varlistentry>
+                    <term><option>appdata-license</option> (string)</term>
+                    <listitem><para>Replace the appdata
+                    project_license field with this string. This is
+                    useful as the upstream license is typically only
+                    about the application itself, whereas the bundled
+                    app can contain other licenses
+                    too. </para></listitem>
+                </varlistentry>
+                <varlistentry>
                     <term><option>copy-icon</option> (boolean)</term>
                     <listitem><para>If rename-icon is set, keep a copy of the old icon file.</para></listitem>
                 </varlistentry>

--- a/src/builder-utils.h
+++ b/src/builder-utils.h
@@ -25,6 +25,8 @@
 #include <libsoup/soup.h>
 #include <json-glib/json-glib.h>
 
+#include <libxml/tree.h>
+
 G_BEGIN_DECLS
 
 typedef struct BuilderUtils BuilderUtils;
@@ -74,6 +76,18 @@ GParamSpec * builder_serializable_find_property_with_error (JsonSerializable *se
 
 void builder_set_term_title (const gchar *format,
                              ...) G_GNUC_PRINTF (1, 2);
+
+static inline void
+xml_autoptr_cleanup_generic_free (void *p)
+{
+  void **pp = (void**)p;
+  if (*pp)
+    xmlFree (*pp);
+}
+
+#define xml_autofree _GLIB_CLEANUP(xml_autoptr_cleanup_generic_free)
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (xmlDoc, xmlFreeDoc)
 
 G_END_DECLS
 


### PR DESCRIPTION
This lets you modify the project_license field in the appdata file.
This is useful because appdata files from upstream generally only
contain license information for the app itself, whereas the
bundled app may contain other code with additional licenses.