### PR TITLE
Automatically compress debug info unless no-debuginfo-compression is set

### DIFF
--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -302,6 +302,10 @@
                     and puts this in an extension. If you want to disable this, set no-debuginfo to true.</para></listitem>
                 </varlistentry>
                 <varlistentry>
+                    <term><option>no-debuginfo-compression</option> (boolean)</term>
+                    <listitem><para>By default when extracting debuginfo we compress the debug sections. If you want to disable this, set no-debuginfo-compression to true.</para></listitem>
+                </varlistentry>
+                <varlistentry>
                     <term><option>arch</option> (object)</term>
                     <listitem><para>This is a dictionary defining for each arch a separate build options object that override the main one.</para></listitem>
                 </varlistentry>

--- a/src/builder-module.c
+++ b/src/builder-module.c
@@ -1653,7 +1653,11 @@ builder_module_build_helper (BuilderModule  *self,
   else if (!builder_options_get_no_debuginfo (self->build_options, context) &&
            /* No support for debuginfo for extensions atm */
            !builder_context_get_build_extension (context))
-    post_process_flags |= BUILDER_POST_PROCESS_FLAGS_DEBUGINFO;
+    {
+      post_process_flags |= BUILDER_POST_PROCESS_FLAGS_DEBUGINFO;
+      if (!builder_options_get_no_debuginfo_compression (self->build_options, context))
+	post_process_flags |= BUILDER_POST_PROCESS_FLAGS_DEBUGINFO_COMPRESSION;
+    }
 
   if (!builder_post_process (post_process_flags, app_dir,
                              cache, context, error))

--- a/src/builder-options.h
+++ b/src/builder-options.h
@@ -66,6 +66,8 @@ void        builder_options_checksum (BuilderOptions *self,
                                       BuilderContext *context);
 gboolean    builder_options_get_no_debuginfo (BuilderOptions *self,
                                               BuilderContext *context);
+gboolean    builder_options_get_no_debuginfo_compression (BuilderOptions *self,
+							  BuilderContext *context);
 gboolean    builder_options_get_strip (BuilderOptions *self,
                                        BuilderContext *context);
 

--- a/src/builder-post-process.h
+++ b/src/builder-post-process.h
@@ -31,6 +31,7 @@ typedef enum {
   BUILDER_POST_PROCESS_FLAGS_PYTHON_TIMESTAMPS  = 1<<0,
   BUILDER_POST_PROCESS_FLAGS_STRIP              = 1<<1,
   BUILDER_POST_PROCESS_FLAGS_DEBUGINFO          = 1<<2,
+  BUILDER_POST_PROCESS_FLAGS_DEBUGINFO_COMPRESSION = 1<<3,
 } BuilderPostProcessFlags;
 
 gboolean builder_post_process (BuilderPostProcessFlags   flags,

--- a/src/builder-utils.c
+++ b/src/builder-utils.c
@@ -159,6 +159,21 @@ eu_strip (GError **error,
   return res;
 }
 
+gboolean
+eu_elfcompress (GError **error,
+		...)
+{
+  gboolean res;
+  va_list ap;
+
+  va_start (ap, error);
+  res = flatpak_spawn (NULL, NULL, error, "eu-elfcompress", ap);
+  va_end (ap);
+
+  return res;
+}
+
+
 static gboolean
 elf_has_symtab (Elf *elf)
 {

--- a/src/builder-utils.h
+++ b/src/builder-utils.h
@@ -37,6 +37,8 @@ gboolean strip (GError **error,
                 ...);
 gboolean eu_strip (GError **error,
                    ...);
+gboolean eu_elfcompress (GError **error,
+			 ...);
 
 gboolean is_elf_file (const char *path,
                       gboolean   *is_shared,

--- a/tests/make-test-runtime.sh
+++ b/tests/make-test-runtime.sh
@@ -25,6 +25,7 @@ mkdir -p ${DIR}/usr/bin
 mkdir -p ${DIR}/usr/lib
 ln -s ../lib ${DIR}/usr/lib64
 ln -s ../lib ${DIR}/usr/lib32
+cp `which ldconfig` ${DIR}/usr/bin
 T=`mktemp`
 for i in $@; do
     I=`which $i`


### PR DESCRIPTION
This uses eu-elfcompress to compress the debuginfo. We use the older
zlib-gnu compression format which is older and has more widespread
support.