### PR TITLE
Do shallow fetches when mirroring git repos

### DIFF
--- a/src/builder-flatpak-utils.c
+++ b/src/builder-flatpak-utils.c
@@ -519,6 +519,7 @@ flatpak_quote_argv (const char *argv[])
 gboolean
 flatpak_spawn (GFile       *dir,
                char       **output,
+               GSubprocessFlags flags,
                GError     **error,
                const gchar *argv0,
                va_list      ap)
@@ -533,7 +534,7 @@ flatpak_spawn (GFile       *dir,
     g_ptr_array_add (args, (gchar *) arg);
   g_ptr_array_add (args, NULL);
 
-  res = flatpak_spawnv (dir, output, 0, error, (const gchar * const *) args->pdata);
+  res = flatpak_spawnv (dir, output, flags, error, (const gchar * const *) args->pdata);
 
   g_ptr_array_free (args, TRUE);
 

--- a/src/builder-flatpak-utils.h
+++ b/src/builder-flatpak-utils.h
@@ -203,6 +203,7 @@ gboolean flatpak_file_arg_has_suffix (const char *arg, const char *suffix);
 
 gboolean            flatpak_spawn (GFile       *dir,
                                    char       **output,
+                                   GSubprocessFlags flags,
                                    GError     **error,
                                    const gchar *argv0,
                                    va_list      args);

--- a/src/builder-git.c
+++ b/src/builder-git.c
@@ -88,7 +88,6 @@ lookup_full_ref (GHashTable *refs, const char *ref)
   };
   GHashTableIter iter;
   gpointer key, value;
-  g_autofree char *lowered = NULL;
 
   for (i = 0; i < G_N_ELEMENTS(prefixes); i++)
     {

--- a/src/builder-git.c
+++ b/src/builder-git.c
@@ -43,7 +43,7 @@ git (GFile   *dir,
   va_list ap;
 
   va_start (ap, error);
-  res = flatpak_spawn (dir, output, error, "git", ap);
+  res = flatpak_spawn (dir, output, 0, error, "git", ap);
   va_end (ap);
 
   return res;

--- a/src/builder-git.c
+++ b/src/builder-git.c
@@ -406,9 +406,10 @@ builder_git_shallow_mirror_ref (const char     *repo_location,
   if (*full_ref == 0)
     {
       g_free (full_ref);
-      full_ref = g_strdup_printf ("flatpak-builder/ref-%s", ref);
+      /* We can't pull the commit id, so we create a ref we can pull */
+      full_ref = g_strdup_printf ("refs/flatpak/ref-%s", ref);
       if (!git (cache_mirror_dir, NULL, 0, NULL,
-                "branch", "-f", full_ref, ref, NULL))
+                "update-ref", full_ref, ref, NULL))
         return FALSE;
     }
 

--- a/src/builder-manifest.c
+++ b/src/builder-manifest.c
@@ -1317,7 +1317,7 @@ flatpak (GError **error,
   va_list ap;
 
   va_start (ap, error);
-  res = flatpak_spawn (NULL, &output, error, "flatpak", ap);
+  res = flatpak_spawn (NULL, &output, 0, error, "flatpak", ap);
   va_end (ap);
 
   if (res)

--- a/src/builder-source-archive.c
+++ b/src/builder-source-archive.c
@@ -351,7 +351,7 @@ tar (GFile   *dir,
   va_list ap;
 
   va_start (ap, error);
-  res = flatpak_spawn (dir, NULL, error, "tar", ap);
+  res = flatpak_spawn (dir, NULL, 0, error, "tar", ap);
   va_end (ap);
 
   return res;
@@ -366,7 +366,7 @@ unzip (GFile   *dir,
   va_list ap;
 
   va_start (ap, error);
-  res = flatpak_spawn (dir, NULL, error, "unzip", ap);
+  res = flatpak_spawn (dir, NULL, 0, error, "unzip", ap);
   va_end (ap);
 
   return res;

--- a/src/builder-source-bzr.c
+++ b/src/builder-source-bzr.c
@@ -124,7 +124,7 @@ bzr (GFile   *dir,
   va_list ap;
 
   va_start (ap, error);
-  res = flatpak_spawn (dir, output, error, "bzr", ap);
+  res = flatpak_spawn (dir, output, 0, error, "bzr", ap);
   va_end (ap);
 
   return res;

--- a/src/builder-utils.c
+++ b/src/builder-utils.c
@@ -139,7 +139,7 @@ strip (GError **error,
   va_list ap;
 
   va_start (ap, error);
-  res = flatpak_spawn (NULL, NULL, error, "strip", ap);
+  res = flatpak_spawn (NULL, NULL, 0, error, "strip", ap);
   va_end (ap);
 
   return res;
@@ -153,7 +153,7 @@ eu_strip (GError **error,
   va_list ap;
 
   va_start (ap, error);
-  res = flatpak_spawn (NULL, NULL, error, "eu-strip", ap);
+  res = flatpak_spawn (NULL, NULL, 0, error, "eu-strip", ap);
   va_end (ap);
 
   return res;
@@ -161,13 +161,13 @@ eu_strip (GError **error,
 
 gboolean
 eu_elfcompress (GError **error,
-		...)
+                ...)
 {
   gboolean res;
   va_list ap;
 
   va_start (ap, error);
-  res = flatpak_spawn (NULL, NULL, error, "eu-elfcompress", ap);
+  res = flatpak_spawn (NULL, NULL, 0, error, "eu-elfcompress", ap);
   va_end (ap);
 
   return res;


### PR DESCRIPTION
When downloading a git repo we try to do a shallow (depth=1) fetch of only the specified target. This normally works fine for branches and tags, but if the commit is a raw SHA1 then it fails, because we can only request refs from the remote.
    
We handle this by doing an ls-remote and seeing if the specified target is either a (possilby partial) ref, or a commit id that a remote ref is pointing at. If it is, we pull that ref only. If not, then we fall back to a full fetch.

I believe this is the best we can do to fix   https://github.com/flatpak/flatpak-builder/issues/6
