### PR TITLE
run: Don't pass --die-with-parent when we --run

### DIFF
--- a/src/builder-manifest.c
+++ b/src/builder-manifest.c
@@ -3427,7 +3427,6 @@ builder_manifest_run (BuilderManifest *self,
   args = g_ptr_array_new_with_free_func (g_free);
   g_ptr_array_add (args, g_strdup ("flatpak"));
   g_ptr_array_add (args, g_strdup ("build"));
-  g_ptr_array_add (args, g_strdup ("--die-with-parent"));
   g_ptr_array_add (args, g_strdup ("--with-appdir"));
 
   build_dir_path = g_file_get_path (builder_context_get_build_dir (context));


### PR DESCRIPTION
In this case we will exec rather than fork + exec, so we don't
want to use prctl, as that can cause the app to die if any
*thread* in the parent dies (rather then the whole process).

In particular, this caused issues for gnome-builder starting
a newly built flatpak:ed app.