### PR TITLE
More shallow git fixes

### DIFF
--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -552,6 +552,10 @@
                         <term><option>disable-fsckobjects</option> (boolean)</term>
                         <listitem><para>Don't use transfer.fsckObjects=1 to mirror git repository. This may be needed for some (broken) repositories.</para></listitem>
                     </varlistentry>
+                    <varlistentry>
+                        <term><option>disable-shallow-clone</option> (boolean)</term>
+                        <listitem><para>Don't optimize by making a shallow clone when downloading the git repo.</para></listitem>
+                    </varlistentry>
                 </variablelist>
             </refsect3>
             <refsect3>

--- a/src/builder-git.h
+++ b/src/builder-git.h
@@ -30,6 +30,7 @@ gboolean builder_git_mirror_repo        (const char      *repo_location,
                                          gboolean         update,
                                          gboolean         mirror_submodules,
                                          gboolean         disable_fsck,
+                                         gboolean         disable_shallow,
                                          const char      *ref,
                                          BuilderContext  *context,
                                          GError         **error);

--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -434,7 +434,7 @@ main (int    argc,
 
       if (!builder_git_mirror_repo (opt_from_git,
                                     NULL,
-                                    !opt_disable_updates, FALSE, FALSE,
+                                    !opt_disable_updates, FALSE, FALSE, FALSE,
                                     git_branch, build_context, &error))
         {
           g_printerr ("Can't clone manifest repo: %s\n", error->message);


### PR DESCRIPTION
This adds a way to disable shallow clones, requested by @directhex, also it disables shallow clones for pre-existing pulls that are not shallow, because this broke for the old version of git we have in the build system. Also, when converting to non-shallow we --unshallow in order to actually get all commits.
