### PR TITLE
Even more fixes, and some cleanups, for git < 1.9.0

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -8,7 +8,7 @@ dn=$(dirname $0)
 
 pkg_install sudo which attr fuse \
     libubsan libasan libtsan elfutils-libelf-devel libdwarf-devel \
-    elfutils git gettext-devel \
+    elfutils git gettext-devel libappstream-glib-devel \
     /usr/bin/{update-mime-database,update-desktop-database,gtk-update-icon-cache}
 pkg_install_testing ostree-devel ostree
 pkg_install_if_os fedora gjs parallel clang

--- a/src/builder-git.c
+++ b/src/builder-git.c
@@ -148,6 +148,12 @@ git_has_version (int major,
   return TRUE;
 }
 
+static gboolean
+git_version_supports_fsck_and_shallow (void)
+{
+  return git_has_version (1,8,3,2);
+}
+
 static GHashTable *
 git_ls_remote (GFile *repo_dir,
                const char *remote,
@@ -427,7 +433,7 @@ builder_git_mirror_repo (const char     *repo_location,
   gboolean was_shallow = FALSE;
   gboolean do_disable_shallow = FALSE;
 
-  gboolean git_supports_fsck_and_shallow = git_has_version (1,8,3,2);
+  gboolean git_supports_fsck_and_shallow = git_version_supports_fsck_and_shallow ();
 
   cache_mirror_dir = git_get_mirror_dir (repo_location, context);
 

--- a/src/builder-git.c
+++ b/src/builder-git.c
@@ -521,7 +521,7 @@ builder_git_mirror_repo (const char     *repo_location,
 
           g_print ("Fetching git repo %s, ref %s\n", repo_location, full_ref);
           if (!git (mirror_dir, NULL, 0, error,
-                    "fetch", "-p", "--no-recurse-submodules", "--no-tags", "--depth=1", "-f",
+                    "fetch", "-p", "--no-recurse-submodules", "--depth=1", "-f",
                     origin, full_ref_mapping, NULL))
             return FALSE;
 
@@ -535,9 +535,10 @@ builder_git_mirror_repo (const char     *repo_location,
 	      !g_str_has_prefix (full_ref, "refs/tags"))
 	    {
 	      g_autofree char *fake_ref = g_strdup_printf ("refs/heads/flatpak-builder-internal/%s", full_ref);
+	      g_autofree char *peeled_full_ref = g_strdup_printf ("%s^{}", full_ref);
 
 	      if (!git (mirror_dir, NULL, 0, NULL,
-			"update-ref", fake_ref, full_ref, NULL))
+			"update-ref", fake_ref, peeled_full_ref, NULL))
 		return FALSE;
 	    }
         }
@@ -627,11 +628,13 @@ builder_git_shallow_mirror_ref (const char     *repo_location,
 
   if (*full_ref == 0)
     {
+      g_autofree char *peeled_ref = g_strdup_printf ("%s^{}", ref);
+
       g_free (full_ref);
       /* We can't pull the commit id, so we create a ref we can pull */
       full_ref = g_strdup_printf ("refs/heads/flatpak-builder-internal/commit/%s", ref);
       if (!git (cache_mirror_dir, NULL, 0, error,
-                "update-ref", full_ref, ref, NULL))
+                "update-ref", full_ref, peeled_ref, NULL))
         return FALSE;
     }
 

--- a/src/builder-git.c
+++ b/src/builder-git.c
@@ -549,7 +549,7 @@ builder_git_mirror_repo (const char     *repo_location,
         {
           g_print ("Fetching full git repo %s\n", repo_location);
           if (!git (mirror_dir, NULL, 0, error,
-                    "fetch", "-p", "--no-recurse-submodules", "--tags", origin,
+                    "fetch", "-p", "--no-recurse-submodules", "--tags", origin, "*:*",
                     was_shallow ? "--unshallow" : NULL,
                     NULL))
             return FALSE;

--- a/src/builder-git.c
+++ b/src/builder-git.c
@@ -154,6 +154,12 @@ git_version_supports_fsck_and_shallow (void)
   return git_has_version (1,8,3,2);
 }
 
+static gboolean
+git_version_supports_fetch_from_shallow (void)
+{
+  return git_has_version (1,9,0,0);
+}
+
 static GHashTable *
 git_ls_remote (GFile *repo_dir,
                const char *remote,
@@ -334,6 +340,11 @@ git_mirror_submodules (const char     *repo_location,
   g_autofree gchar **submodules = NULL;
   g_autofree gchar *gitmodules = g_strconcat (revision, ":.gitmodules", NULL);
   gsize num_submodules;
+
+  /* Older versions of git can't fetch from shallow repos, so always clone submodule
+     repos deeply so git submodule update works */
+  if (!git_version_supports_fetch_from_shallow ())
+    disable_shallow = TRUE;
 
   if (!git (mirror_dir, &rev_parse_output, 0, NULL, "rev-parse", "--verify", "--quiet", gitmodules, NULL))
     return TRUE;

--- a/src/builder-git.c
+++ b/src/builder-git.c
@@ -618,7 +618,7 @@ builder_git_shallow_mirror_ref (const char     *repo_location,
         return FALSE;
     }
 
-  if (!git (cache_mirror_dir, &full_ref, 0, NULL,
+  if (!git (cache_mirror_dir, &full_ref, 0, error,
             "rev-parse", "--symbolic-full-name", ref, NULL))
     return FALSE;
 
@@ -630,7 +630,7 @@ builder_git_shallow_mirror_ref (const char     *repo_location,
       g_free (full_ref);
       /* We can't pull the commit id, so we create a ref we can pull */
       full_ref = g_strdup_printf ("refs/heads/flatpak-builder-internal/commit/%s", ref);
-      if (!git (cache_mirror_dir, NULL, 0, NULL,
+      if (!git (cache_mirror_dir, NULL, 0, error,
                 "update-ref", full_ref, ref, NULL))
         return FALSE;
     }

--- a/src/builder-git.h
+++ b/src/builder-git.h
@@ -30,6 +30,7 @@ typedef enum {
   FLATPAK_GIT_MIRROR_FLAGS_MIRROR_SUBMODULES = 1 << 1,
   FLATPAK_GIT_MIRROR_FLAGS_DISABLE_FSCK = 1 << 2,
   FLATPAK_GIT_MIRROR_FLAGS_DISABLE_SHALLOW = 1 << 3,
+  FLATPAK_GIT_MIRROR_FLAGS_WILL_FETCH_FROM = 1 << 4,
 } FlatpakGitMirrorFlags;
 
 gboolean builder_git_mirror_repo        (const char      *repo_location,

--- a/src/builder-git.h
+++ b/src/builder-git.h
@@ -25,12 +25,16 @@
 
 G_BEGIN_DECLS
 
+typedef enum {
+  FLATPAK_GIT_MIRROR_FLAGS_UPDATE = 1 << 0,
+  FLATPAK_GIT_MIRROR_FLAGS_MIRROR_SUBMODULES = 1 << 1,
+  FLATPAK_GIT_MIRROR_FLAGS_DISABLE_FSCK = 1 << 2,
+  FLATPAK_GIT_MIRROR_FLAGS_DISABLE_SHALLOW = 1 << 3,
+} FlatpakGitMirrorFlags;
+
 gboolean builder_git_mirror_repo        (const char      *repo_location,
                                          const char      *destination_path,
-                                         gboolean         update,
-                                         gboolean         mirror_submodules,
-                                         gboolean         disable_fsck,
-                                         gboolean         disable_shallow,
+                                         FlatpakGitMirrorFlags flags,
                                          const char      *ref,
                                          BuilderContext  *context,
                                          GError         **error);
@@ -52,7 +56,6 @@ gboolean builder_git_checkout_dir       (const char      *repo_location,
                                          GError         **error);
 gboolean builder_git_shallow_mirror_ref (const char     *repo_location,
                                          const char     *destination_path,
-                                         gboolean        mirror_submodules,
                                          const char     *ref,
                                          BuilderContext *context,
                                          GError        **error);

--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -442,7 +442,7 @@ main (int    argc,
 
       if (!builder_git_mirror_repo (opt_from_git,
                                     NULL,
-                                    !opt_disable_updates, FALSE, FALSE, FALSE,
+                                    opt_disable_updates?0:FLATPAK_GIT_MIRROR_FLAGS_UPDATE,
                                     git_branch, build_context, &error))
         {
           g_printerr ("Can't clone manifest repo: %s\n", error->message);

--- a/src/builder-source-git.c
+++ b/src/builder-source-git.c
@@ -242,6 +242,8 @@ builder_source_git_download (BuilderSource  *source,
     flags |= FLATPAK_GIT_MIRROR_FLAGS_DISABLE_FSCK;
   if (self->disable_shallow_clone)
     flags |= FLATPAK_GIT_MIRROR_FLAGS_DISABLE_SHALLOW;
+  if (builder_context_get_bundle_sources (context))
+    flags |= FLATPAK_GIT_MIRROR_FLAGS_WILL_FETCH_FROM;
 
   if (!builder_git_mirror_repo (location, NULL, flags,
                                 get_branch (self),


### PR DESCRIPTION
With this i managed to build my git testcase both with and without --bundle-sources.