### PR TITLE
Add support for running tests

### DIFF
--- a/doc/flatpak-builder.xml
+++ b/doc/flatpak-builder.xml
@@ -204,6 +204,14 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--disable-tests</option></term>
+
+                <listitem><para>
+                    Don't run any of the tests.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--run</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -290,6 +290,10 @@
                     <listitem><para>This is an array containing extra options to pass to flatpak build.</para></listitem>
                 </varlistentry>
                 <varlistentry>
+                    <term><option>test-args</option> (array of strings)</term>
+                    <listitem><para>Similar to build-args but affects the tests, not the normal build.</para></listitem>
+                </varlistentry>
+                <varlistentry>
                     <term><option>config-opts</option> (array of strings)</term>
                     <listitem><para>This is an array containing extra options to pass to configure.</para></listitem>
                 </varlistentry>
@@ -469,6 +473,18 @@
                 <varlistentry>
                     <term><option>cleanup-platform</option> (array of strings)</term>
                     <listitem><para>Extra files to clean up in the platform.</para></listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term><option>run-tests</option> (boolean)</term>
+                    <listitem><para>If true this will run the tests after installing.</para></listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term><option>test-rule</option> (string)</term>
+                    <listitem><para>The target to build when running the tests. Defaults to "check" for make and "test" for ninja. Set to empty to disable.</para></listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term><option>test-commands</option> (arrya of string)</term>
+                    <listitem><para>Array of commands to run during the tests.</para></listitem>
                 </varlistentry>
                 <varlistentry>
                     <term><option>modules</option> (array of objects or strings)</term>

--- a/src/builder-context.c
+++ b/src/builder-context.c
@@ -75,6 +75,7 @@ struct BuilderContext
   gboolean        rebuild_on_sdk_change;
   gboolean        use_rofiles;
   gboolean        have_rofiles;
+  gboolean        run_tests;
 };
 
 typedef struct
@@ -824,6 +825,19 @@ builder_context_set_use_rofiles (BuilderContext *self,
                                  gboolean use_rofiles)
 {
   self->use_rofiles = use_rofiles;
+}
+
+gboolean
+builder_context_get_run_tests (BuilderContext *self)
+{
+  return self->run_tests;
+}
+
+void
+builder_context_set_run_tests (BuilderContext *self,
+                               gboolean run_tests)
+{
+  self->run_tests = run_tests;
 }
 
 gboolean

--- a/src/builder-context.h
+++ b/src/builder-context.h
@@ -125,6 +125,9 @@ gboolean        builder_context_get_rofiles_active (BuilderContext *self);
 gboolean        builder_context_get_use_rofiles (BuilderContext *self);
 void            builder_context_set_use_rofiles (BuilderContext *self,
                                                  gboolean use_rofiles);
+gboolean        builder_context_get_run_tests (BuilderContext *self);
+void            builder_context_set_run_tests (BuilderContext *self,
+                                               gboolean run_tests);
 char **         builder_context_extend_env (BuilderContext *self,
                                             char          **envp);
 

--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -38,6 +38,7 @@ static gboolean opt_verbose;
 static gboolean opt_version;
 static gboolean opt_run;
 static gboolean opt_disable_cache;
+static gboolean opt_disable_tests;
 static gboolean opt_disable_rofiles;
 static gboolean opt_download_only;
 static gboolean opt_bundle_sources;
@@ -87,6 +88,7 @@ static GOptionEntry entries[] = {
   { "run", 0, 0, G_OPTION_ARG_NONE, &opt_run, "Run a command in the build directory (see --run --help)", NULL },
   { "ccache", 0, 0, G_OPTION_ARG_NONE, &opt_ccache, "Use ccache", NULL },
   { "disable-cache", 0, 0, G_OPTION_ARG_NONE, &opt_disable_cache, "Disable cache lookups", NULL },
+  { "disable-tests", 0, 0, G_OPTION_ARG_NONE, &opt_disable_tests, "Don't run tests", NULL },
   { "disable-rofiles-fuse", 0, 0, G_OPTION_ARG_NONE, &opt_disable_rofiles, "Disable rofiles-fuse use", NULL },
   { "disable-download", 0, 0, G_OPTION_ARG_NONE, &opt_disable_download, "Don't download any new sources", NULL },
   { "disable-updates", 0, 0, G_OPTION_ARG_NONE, &opt_disable_updates, "Only download missing sources, never update to latest vcs version", NULL },
@@ -377,6 +379,7 @@ main (int    argc,
   build_context = builder_context_new (cwd_dir, app_dir);
 
   builder_context_set_use_rofiles (build_context, !opt_disable_rofiles);
+  builder_context_set_run_tests (build_context, !opt_disable_tests);
   builder_context_set_keep_build_dirs (build_context, opt_keep_build_dirs);
   builder_context_set_delete_build_dirs (build_context, opt_delete_build_dirs);
   builder_context_set_sandboxed (build_context, opt_sandboxed);

--- a/src/builder-options.h
+++ b/src/builder-options.h
@@ -52,6 +52,9 @@ char **     builder_options_get_env (BuilderOptions *self,
 char **     builder_options_get_build_args (BuilderOptions *self,
                                             BuilderContext *context,
                                             GError **error);
+char **     builder_options_get_test_args (BuilderOptions *self,
+                                            BuilderContext *context,
+                                            GError **error);
 char **     builder_options_get_config_opts (BuilderOptions *self,
                                              BuilderContext *context,
                                              char          **base_opts);


### PR DESCRIPTION
Modules that say "run-tests": true, will run tests after installation,
unless disabled by --disable-tests.

The tests run by default are make check or ninja test, however you
can control the make/ninja target with test-rule, or supply a list
of commands with test-commands. There is also a test-args argument
in build-options, which you can use to give e.g. network access.

The tests are run with readonly access to the install directory, so
they cannot affect the build results.

This depends on https://github.com/flatpak/flatpak/pull/1172 for the --readonly flag.
