### PR TITLE
Change debug output from XAB to FB

### DIFF
--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -153,7 +153,7 @@ message_handler (const gchar   *log_domain,
 {
   /* Make this look like normal console output */
   if (log_level & G_LOG_LEVEL_DEBUG)
-    g_printerr ("XAB: %s\n", message);
+    g_printerr ("FB: %s\n", message);
   else
     g_printerr ("%s: %s\n", g_get_prgname (), message);
 }


### PR DESCRIPTION
This is no longer xdg-app-builder, but flatpak-builder.