### PR TITLE
Add --enable-p2p configure option

### DIFF
--- a/buildutil/glib-tap.mk
+++ b/buildutil/glib-tap.mk
@@ -118,7 +118,8 @@ installed_testcases = $(test_programs) $(installed_test_programs) \
 installed_test_meta_DATA = $(installed_testcases:=.test)
 
 %.test: %$(EXEEXT) Makefile
-	$(AM_V_GEN) (echo '[Test]' > $@.tmp; \
+	$(AM_V_GEN) (mkdir -p $(@D); \
+	echo '[Test]' > $@.tmp; \
 	echo 'Type=session' >> $@.tmp; \
 	echo 'Exec=env G_TEST_SRCDIR=$(installed_testdir) G_TEST_BUILDDIR=$(installed_testdir)  $(installed_testdir)/$(notdir $<) --tap' >> $@.tmp; \
 	echo 'Output=TAP' >> $@.tmp; \

--- a/configure.ac
+++ b/configure.ac
@@ -145,6 +145,28 @@ AS_IF([test "x$with_dwarf_header" = "xyes"],
        AS_IF([test "x$ac_cv_header_dwarf_h" != "xyes"],
              [AC_MSG_ERROR([dwarf.h is required but was not found])])])
 
+# Do we enable building peer to peer support using libostree’s experimental (non-stable) API?
+# If so, OSTREE_ENABLE_EXPERIMENTAL_API needs to be #defined before ostree.h is
+# included.
+AC_ARG_ENABLE([p2p],
+  [AS_HELP_STRING([--enable-p2p],
+                  [Enable unstable peer to peer support [default=no]])],,
+  [enable_p2p=no])
+AS_IF([test x$enable_p2p = xyes],[
+  PKG_CHECK_MODULES(OSTREE, [ostree-1 >= $OSTREE_REQS])
+
+  ostree_features=$($PKG_CONFIG --variable=features ostree-1)
+  AS_CASE(["$ostree_features"],
+          [*experimental*],[have_ostree_experimental=yes])
+
+  AS_IF([test "x$have_ostree_experimental" != "xyes"],
+        [AC_MSG_ERROR([Experimental API not found in ostree-1, which is needed for --enable-p2p. OSTree must be compiled with --enable-experimental-api.])])
+
+  AC_DEFINE([OSTREE_ENABLE_EXPERIMENTAL_API],[1],[Define if libostree experimental API should be enabled])
+  AC_DEFINE([FLATPAK_ENABLE_P2P],[1],[Define if peer to peer support should be enabled])
+])
+AM_CONDITIONAL([ENABLE_P2P],[test x$enable_p2p = xyes])
+
 AC_ARG_ENABLE(documentation,
               AC_HELP_STRING([--enable-documentation], [Build documentation]),,
               enable_documentation=yes)


### PR DESCRIPTION
This got omitted when flatpak-builder was split from flatpak.git. Also fix clean builddir ≠ srcdir builds.