### PR TITLE
tests: Skip tests if fuse is not available

### DIFF
--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -291,6 +291,15 @@ run_sh () {
     ${CMD_PREFIX} flatpak run --command=bash ${ARGS-} org.test.Hello -c "$*"
 }
 
+# fuse support is needed (and the kernel module needs to be loaded) for several
+# flatpak-builder tests
+skip_without_fuse () {
+    if [ ! -w /dev/fuse ] || ! command -v fusermount >/dev/null; then
+        echo "1..0 # SKIP this test requires fuse support"
+        exit 0
+    fi
+}
+
 skip_without_python2 () {
     if ! test -f /usr/bin/python2 || ! /usr/bin/python2 -c "import sys; sys.exit(0 if sys.version_info >= (2, 7) else 1)" ; then
         echo "1..0 # SKIP this test requires /usr/bin/python2 (2.7) support"

--- a/tests/test-builder-python.sh
+++ b/tests/test-builder-python.sh
@@ -21,6 +21,7 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
+skip_without_fuse
 skip_without_python2
 
 echo "1..2"

--- a/tests/test-builder.sh
+++ b/tests/test-builder.sh
@@ -21,6 +21,8 @@ set -euo pipefail
 
 . $(dirname $0)/libtest.sh
 
+skip_without_fuse
+
 echo "1..4"
 
 setup_repo


### PR DESCRIPTION
If fuse is not available (for example, the kernel module is not loaded,
or /dev/fuse is not exposed in a build chroot), the tests will currently
fail. Avoid that by skipping them gracefully.

Signed-off-by: Philip Withnall <withnall@endlessm.com>