### PR TITLE
Support including json snippet for sources

### DIFF
--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -376,8 +376,12 @@
                     <listitem><para>If true, skip this module</para></listitem>
                 </varlistentry>
                 <varlistentry>
-                    <term><option>sources</option> (array of objects)</term>
-                    <listitem><para>An array of objects defining sources that will be downloaded and extracted in order</para></listitem>
+                    <term><option>sources</option> (array of objects or string)</term>
+                    <listitem><para>An array of objects defining
+                    sources that will be downloaded and extracted in
+                    order. String members in the array are interpreted
+                    as the name of a separate json file that contains
+                    sources.  See below for details.</para></listitem>
                 </varlistentry>
                 <varlistentry>
                     <term><option>config-opts</option> (array of strings)</term>
@@ -498,6 +502,11 @@
             <para>
                 These contain a pointer to the source that will be extracted into the source directory before
                 the build starts. They can be of several types, distinguished by the type property.
+            </para>
+            <para>
+                Additionally, the sources list can contain a plain string, which is interpreted as the name
+                of a separate json file that is read and inserted at this point. The json file can contain
+                a single source, or an array of sources.
             </para>
             <refsect3>
                 <title>All sources</title>

--- a/src/builder-flatpak-utils.h
+++ b/src/builder-flatpak-utils.h
@@ -276,6 +276,16 @@ flatpak_temp_dir_destroy (void *p)
 typedef GFile FlatpakTempDir;
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakTempDir, flatpak_temp_dir_destroy)
 
+static inline void
+builder_object_list_destroy (void *p)
+{
+  GList *list = p;
+
+  g_list_free_full (list, g_object_unref);
+}
+
+typedef GList BuilderObjectList;
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (BuilderObjectList, builder_object_list_destroy)
 
 #define AUTOLOCK(name) G_GNUC_UNUSED __attribute__((cleanup (flatpak_auto_unlock_helper))) GMutex * G_PASTE (auto_unlock, __LINE__) = flatpak_auto_lock_helper (&G_LOCK_NAME (name))
 


### PR DESCRIPTION
Support including json snippet for sources

This allows inclusion of sources from an external json source similar to how we do it for modules.
    
For example, you can use:

    "sources": [
        {
            "type": "shell",
            "commands": [ "echo BEFORE include" ]
        },
        "include.json",
        {
            "type": "shell",
            "commands": [ "echo AFTER include" ]
        }
    ]
    
with include.json containing:

    [
        {
            "type": "shell",
            "commands": [ "echo Shell 1" ]
        },
        {
            "type": "shell",
            "commands": [ "echo Shell 2" ]
        }
    ]
    
This is very useful in the case where the included file is  auto-generated from some other source, such as an npm lockfile.
