### PR TITLE
Use canonical formats in cache and use bare-user-only repo

### DIFF
--- a/src/builder-cache.c
+++ b/src/builder-cache.c
@@ -248,7 +248,7 @@ builder_cache_open (BuilderCache *self,
       if (!flatpak_mkdir_p (parent, NULL, error))
         return FALSE;
 
-      if (!ostree_repo_create (self->repo, OSTREE_REPO_MODE_BARE_USER, NULL, error))
+      if (!ostree_repo_create (self->repo, OSTREE_REPO_MODE_BARE_USER_ONLY, NULL, error))
         return FALSE;
     }
 

--- a/src/builder-manifest.h
+++ b/src/builder-manifest.h
@@ -38,7 +38,7 @@ typedef struct BuilderManifest BuilderManifest;
 #define BUILDER_IS_MANIFEST(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), BUILDER_TYPE_MANIFEST))
 
 /* Bump this if format changes in incompatible ways to force rebuild */
-#define BUILDER_MANIFEST_CHECKSUM_VERSION "4"
+#define BUILDER_MANIFEST_CHECKSUM_VERSION "5"
 #define BUILDER_MANIFEST_CHECKSUM_CLEANUP_VERSION "1"
 #define BUILDER_MANIFEST_CHECKSUM_FINISH_VERSION "2"
 #define BUILDER_MANIFEST_CHECKSUM_BUNDLE_SOURCES_VERSION "1"


### PR DESCRIPTION
This means builds work on filesystems without xattrs, and that the cache repo modes matches the outpuf from flatpak build-export, which can be useful in some cases.