### PR TITLE
Add --install argument

### DIFF
--- a/doc/flatpak-builder.xml
+++ b/doc/flatpak-builder.xml
@@ -547,6 +547,14 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--install</option></term>
+
+                <listitem><para>
+                    When the build is finished, install the result locally.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--user</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-builder.xml
+++ b/doc/flatpak-builder.xml
@@ -558,7 +558,7 @@
                 <term><option>--system</option></term>
 
                 <listitem><para>
-                    Install the dependenceis in the default system-wide installation.
+                    Install the dependencies in the default system-wide installation.
                 </para></listitem>
             </varlistentry>
 

--- a/src/builder-flatpak-utils.c
+++ b/src/builder-flatpak-utils.c
@@ -399,8 +399,7 @@ char *
 flatpak_compose_ref (gboolean    app,
                      const char *name,
                      const char *branch,
-                     const char *arch,
-                     GError    **error)
+                     const char *arch)
 {
   if (app)
     return flatpak_build_app_ref (name, branch, arch);

--- a/src/builder-flatpak-utils.h
+++ b/src/builder-flatpak-utils.h
@@ -130,8 +130,7 @@ char **flatpak_decompose_ref (const char *ref,
 char * flatpak_compose_ref (gboolean    app,
                             const char *name,
                             const char *branch,
-                            const char *arch,
-                            GError    **error);
+                            const char *arch);
 
 char * flatpak_build_untyped_ref (const char *runtime,
                                   const char *branch,

--- a/src/builder-manifest.c
+++ b/src/builder-manifest.c
@@ -2493,9 +2493,7 @@ builder_manifest_finish (BuilderManifest *self,
       ref = flatpak_compose_ref (!self->build_runtime && !self->build_extension,
                                  builder_manifest_get_id (self),
                                  builder_manifest_get_branch (self),
-                                 builder_context_get_arch (context), error);
-      if (ref == NULL)
-        return FALSE;
+                                 builder_context_get_arch (context));
 
       if (self->metadata)
         {
@@ -2872,9 +2870,7 @@ builder_manifest_create_platform (BuilderManifest *self,
       ref = flatpak_compose_ref (!self->build_runtime && !self->build_extension,
                                  builder_manifest_get_id_platform (self),
                                  builder_manifest_get_branch (self),
-                                 builder_context_get_arch (context), error);
-      if (ref == NULL)
-        return FALSE;
+                                 builder_context_get_arch (context));
 
       platform_dir = g_file_get_child (app_dir, "platform");
 


### PR DESCRIPTION
This allows you to build and install the result in a single operation. If a --repo is given the app is installed from there, otherwise we  build-export it to the flatpak-builder cache repo, which already has all the objects that are needed in it, so this will not increase disk-use.

Note, this is WIP, because we depend on https://github.com/flatpak/flatpak/pull/1244, as well as having merged #80 into the PR. Once we have these in officially we can rebase the PR.
