### PR TITLE
docs: fix "concatinated" and "inbetween" typos

### DIFF
--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -247,19 +247,19 @@
             <variablelist>
                 <varlistentry>
                     <term><option>cflags</option> (string)</term>
-                    <listitem><para>This is set in the environment variable CFLAGS during the build. Multiple specifications of this (in e.g. per-arch area) are concatinated with spaces inbetween.</para></listitem>
+                    <listitem><para>This is set in the environment variable CFLAGS during the build. Multiple specifications of this (in e.g. per-arch area) are concatenated, separated by spaces.</para></listitem>
                 </varlistentry>
                 <varlistentry>
                     <term><option>cppflags</option> (string)</term>
-                    <listitem><para>This is set in the environment variable CPPFLAGS during the build. Multiple specifications of this (in e.g. per-arch area) are concatinated with spaces inbetween.</para></listitem>
+                    <listitem><para>This is set in the environment variable CPPFLAGS during the build. Multiple specifications of this (in e.g. per-arch area) are concatenated, separated by spaces.</para></listitem>
                 </varlistentry>
                 <varlistentry>
                     <term><option>cxxflags</option> (string)</term>
-                    <listitem><para>This is set in the environment variable CXXFLAGS during the build. Multiple specifications of this (in e.g. per-arch area) are concatinated with spaces inbetween.</para></listitem>
+                    <listitem><para>This is set in the environment variable CXXFLAGS during the build. Multiple specifications of this (in e.g. per-arch area) are concatenated, separated by spaces.</para></listitem>
                 </varlistentry>
                 <varlistentry>
                     <term><option>ldflags</option> (string)</term>
-                    <listitem><para>This is set in the environment variable LDFLAGS during the build. Multiple specifications of this (in e.g. per-arch area) are concatinated with spaces inbetween.</para></listitem>
+                    <listitem><para>This is set in the environment variable LDFLAGS during the build. Multiple specifications of this (in e.g. per-arch area) are concatenated, separated by spaces.</para></listitem>
                 </varlistentry>
                 <varlistentry>
                     <term><option>prefix</option> (string)</term>


### PR DESCRIPTION
"In between" is two separate words, but I think rewording it is clearer.