### PR TITLE
context: check state-dir when locating sources

### DIFF
--- a/src/builder-context.c
+++ b/src/builder-context.c
@@ -302,6 +302,19 @@ builder_context_find_in_sources_dirs_va (BuilderContext *self,
 {
   int i;
 
+  if (self->state_dir != NULL)
+    {
+      g_autoptr(GFile) local_file = NULL;
+      va_list args2;
+
+      va_copy (args2, args);
+      local_file = flatpak_build_file_va (self->state_dir, args2);
+      va_end (args2);
+
+      if (g_file_query_exists (local_file, NULL))
+        return g_steal_pointer (&local_file);
+    }
+
   if (self->sources_dirs == NULL)
     return NULL;
 


### PR DESCRIPTION
If --state-dir is provided, we might want to find the sources directory
within that path. This fixes an issue with Builder where it fails to
locate the source-dir and therefore always pings the remote git URL.