### PR TITLE
Fix git downloads with --disable-updates

### DIFF
--- a/src/builder-flatpak-utils.c
+++ b/src/builder-flatpak-utils.c
@@ -897,6 +897,23 @@ flatpak_rm_rf (GFile         *dir,
                                cancellable, error);
 }
 
+gboolean flatpak_file_rename (GFile *from,
+                              GFile *to,
+                              GCancellable  *cancellable,
+                              GError       **error)
+{
+  if (g_cancellable_set_error_if_cancelled (cancellable, error))
+    return FALSE;
+
+  if (rename (flatpak_file_get_path_cached (from),
+              flatpak_file_get_path_cached (to)) < 0)
+    {
+      glnx_set_error_from_errno (error);
+      return FALSE;
+    }
+
+  return TRUE;
+}
 
 #define OSTREE_GIO_FAST_QUERYINFO ("standard::name,standard::type,standard::size,standard::is-symlink,standard::symlink-target," \
                                    "unix::device,unix::inode,unix::mode,unix::uid,unix::gid,unix::rdev")

--- a/src/builder-flatpak-utils.h
+++ b/src/builder-flatpak-utils.h
@@ -221,6 +221,11 @@ GFile *flatpak_build_file_va (GFile *base,
                               va_list args);
 GFile *flatpak_build_file (GFile *base, ...) G_GNUC_NULL_TERMINATED;
 
+gboolean flatpak_file_rename (GFile *from,
+                              GFile *to,
+                              GCancellable  *cancellable,
+                              GError       **error);
+
 gboolean flatpak_openat_noatime (int            dfd,
                                  const char    *name,
                                  int           *ret_fd,

--- a/src/builder-git.c
+++ b/src/builder-git.c
@@ -440,6 +440,8 @@ builder_git_mirror_repo (const char     *repo_location,
 {
   g_autoptr(GFile) cache_mirror_dir = NULL;
   g_autoptr(GFile) mirror_dir = NULL;
+  g_autoptr(GFile) real_mirror_dir = NULL;
+  g_autoptr(FlatpakTempDir) tmp_mirror_dir = NULL;
   g_autofree char *current_commit = NULL;
   g_autoptr(GHashTable) refs = NULL;
   gboolean already_exists = FALSE;
@@ -466,6 +468,15 @@ builder_git_mirror_repo (const char     *repo_location,
 
   if (!g_file_query_exists (mirror_dir, NULL))
     {
+      g_autofree char *tmpdir = g_strconcat (flatpak_file_get_path_cached (mirror_dir), "-XXXXXX", NULL);
+
+      if (g_mkdtemp_full (tmpdir, 0755) == NULL)
+        return flatpak_fail (error, "Can't create temporary directory");
+
+      tmp_mirror_dir = g_file_new_for_path (tmpdir);
+      real_mirror_dir = g_steal_pointer (&mirror_dir);
+      mirror_dir = g_object_ref (tmp_mirror_dir);
+
       if (!git (NULL, NULL, 0, error,
                 "init", "--bare",
                 (char *)flatpak_file_get_path_cached (mirror_dir), NULL))
@@ -603,6 +614,14 @@ builder_git_mirror_repo (const char     *repo_location,
               !g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
             g_debug ("Error deleting alternates file: %s", local_error->message);
         }
+    }
+
+  if (real_mirror_dir)
+    {
+      if (!flatpak_file_rename (mirror_dir, real_mirror_dir, NULL, error))
+        return FALSE;
+      g_clear_object (&mirror_dir);
+      mirror_dir = g_steal_pointer (&real_mirror_dir);
     }
 
   if (flags & FLATPAK_GIT_MIRROR_FLAGS_MIRROR_SUBMODULES)

--- a/src/builder-git.c
+++ b/src/builder-git.c
@@ -516,9 +516,15 @@ builder_git_mirror_repo (const char     *repo_location,
         cached_git_dir = g_object_ref (cache_mirror_dir);
 
       /* If we're not updating, only pull from cache to avoid network i/o */
-      if (!update && cached_git_dir)
-        origin = g_file_get_uri (cached_git_dir);
-      else
+      if (!update)
+        {
+          if (cached_git_dir)
+            origin = g_file_get_uri (cached_git_dir);
+          else if (!created)
+            return TRUE;
+        }
+
+      if (origin == NULL)
         origin = g_strdup ("origin");
 
       refs = git_ls_remote (mirror_dir, origin, error);


### PR DESCRIPTION
We regressed in --disable-updates in for git sources, as they were always downloaded, as per https://github.com/flatpak/flatpak-builder/pull/97

This fixes that, and also makes intial download a bit more robust by using a temporary destination.