### PR TITLE
Fix running flatpak-builder from inside flatpak

### DIFF
--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -830,6 +830,7 @@ main (int    argc,
         {
           if (!builder_maybe_host_spawnv (NULL,
                                           NULL,
+                                          0,
                                           &error,
                                           argv))
             {

--- a/src/builder-manifest.c
+++ b/src/builder-manifest.c
@@ -1867,7 +1867,7 @@ command (GFile      *app_dir,
   g_ptr_array_add (args, g_strdup (commandline));
   g_ptr_array_add (args, NULL);
 
-  return builder_maybe_host_spawnv (NULL, NULL, error, (const char * const *)args->pdata);
+  return builder_maybe_host_spawnv (NULL, NULL, 0, error, (const char * const *)args->pdata);
 }
 
 typedef gboolean (*ForeachFileFunc) (BuilderManifest *self,
@@ -2037,7 +2037,7 @@ appstream_compose (GFile   *app_dir,
   g_ptr_array_add (args, NULL);
   va_end (ap);
 
-  if (!builder_maybe_host_spawnv (NULL, NULL, error, (const char * const *)args->pdata))
+  if (!builder_maybe_host_spawnv (NULL, NULL, 0, error, (const char * const *)args->pdata))
     {
       g_prefix_error (error, "ERROR: appstream-compose failed: ");
       return FALSE;

--- a/src/builder-module.c
+++ b/src/builder-module.c
@@ -1279,7 +1279,7 @@ build (GFile          *app_dir,
 
   g_ptr_array_add (args, NULL);
 
-  if (!builder_maybe_host_spawnv (cwd_file, NULL, error, (const char * const *)args->pdata))
+  if (!builder_maybe_host_spawnv (cwd_file, NULL, 0, error, (const char * const *)args->pdata))
     {
       g_prefix_error (error, "module %s: ", module_name);
       return FALSE;

--- a/src/builder-source-shell.c
+++ b/src/builder-source-shell.c
@@ -160,7 +160,7 @@ run_script (BuilderContext *context,
 
   source_dir_path_canonical_file = g_file_new_for_path (source_dir_path_canonical);
 
-  return builder_maybe_host_spawnv (source_dir_path_canonical_file, NULL, error, (const char * const *)args->pdata);
+  return builder_maybe_host_spawnv (source_dir_path_canonical_file, NULL, 0, error, (const char * const *)args->pdata);
 }
 
 

--- a/src/builder-utils.c
+++ b/src/builder-utils.c
@@ -1409,7 +1409,7 @@ host_command_exited_cb (GDBusConnection *connection,
 
   if (client_pid == data->client_pid)
     {
-      g_print ("host_command_exited_cb %d %d\n", client_pid, exit_status);
+      g_debug ("host_command_exited_cb %d %d\n", client_pid, exit_status);
       data->exit_status = exit_status;
       host_command_call_exit (data);
     }

--- a/src/builder-utils.c
+++ b/src/builder-utils.c
@@ -1575,6 +1575,11 @@ builder_host_spawnv (GFile                *dir,
   g_variant_get (ret, "(u)", &client_pid);
   data.client_pid = client_pid;
 
+  /* Drop the FDList immediately or splice_async() may not
+   * complete when the peer process exists, causing us to hang.
+   */
+  g_clear_object (&fd_list);
+
   g_main_loop_run (loop);
 
   g_source_remove (sigterm_id);

--- a/src/builder-utils.c
+++ b/src/builder-utils.c
@@ -1456,6 +1456,7 @@ sigint_handler (gpointer user_data)
 gboolean
 builder_host_spawnv (GFile                *dir,
                      char                **output,
+                     GSubprocessFlags      flags,
                      GError              **error,
                      const gchar * const  *argv)
 {
@@ -1611,13 +1612,14 @@ builder_host_spawnv (GFile                *dir,
 gboolean
 builder_maybe_host_spawnv (GFile                *dir,
                            char                **output,
+                           GSubprocessFlags      flags,
                            GError              **error,
                            const gchar * const  *argv)
 {
   if (flatpak_is_in_sandbox ())
-    return builder_host_spawnv (dir, output, error, argv);
+    return builder_host_spawnv (dir, output, 0, error, argv);
 
-  return flatpak_spawnv (dir, output, 0, error, argv);
+  return flatpak_spawnv (dir, output, flags, error, argv);
 }
 
 /**

--- a/src/builder-utils.h
+++ b/src/builder-utils.h
@@ -63,10 +63,12 @@ gboolean builder_migrate_locale_dirs (GFile   *root_dir,
 
 gboolean builder_host_spawnv (GFile                *dir,
                               char                **output,
+                              GSubprocessFlags      flags,
                               GError              **error,
                               const gchar * const  *argv);
 gboolean builder_maybe_host_spawnv (GFile                *dir,
                                     char                **output,
+                                    GSubprocessFlags      flags,
                                     GError              **error,
                                     const gchar * const  *argv);
 


### PR DESCRIPTION
This series of patches allows us to be able to run a bundled `flatpak-builder` with Builder and execute the necessary `flatpak` operations on the host.

There may still be some operations that are direct subprocesses (build-export, etc), but I couldn't justify why they should run on the host so I left them as is.

One of the interesting fixes in this series is the GUnixFDList fix. Without that, running on the host would indefinitely block while waiting for an async splice to occur.