### PR TITLE
Add support for -y, passed on to all install commands

### DIFF
--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -81,6 +81,7 @@ static gboolean opt_user;
 static char *opt_installation;
 static gboolean opt_log_session_bus;
 static gboolean opt_log_system_bus;
+static gboolean opt_yes;
 
 static GOptionEntry entries[] = {
   { "verbose", 'v', 0, G_OPTION_ARG_NONE, &opt_verbose, "Print debug information during command processing", NULL },
@@ -131,6 +132,7 @@ static GOptionEntry entries[] = {
   { "system", 0, G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE, &opt_user, "Install dependencies in system-wide installations (default)", NULL },
   { "installation", 0, 0, G_OPTION_ARG_STRING, &opt_installation, "Install dependencies in a specific system-wide installation", "NAME" },
   { "state-dir", 0, 0, G_OPTION_ARG_FILENAME, &opt_state_dir, "Use this directory for state instead of .flatpak-builder", "PATH" },
+  { "assumeyes", 'y', 0, G_OPTION_ARG_NONE, &opt_yes, N_("Automatically answer yes for all questions"), NULL },
   { NULL }
 };
 
@@ -272,6 +274,9 @@ do_install (BuilderContext *build_context,
     g_ptr_array_add (args, g_strdup_printf ("--installation=%s", opt_installation));
   else
     g_ptr_array_add (args, g_strdup ("--system"));
+
+  if (opt_user)
+    g_ptr_array_add (args, g_strdup ("-y"));
 
   g_ptr_array_add (args, g_strdup ("--reinstall"));
 
@@ -591,7 +596,8 @@ main (int    argc,
 
   if (opt_install_deps_from != NULL)
     {
-      if (!builder_manifest_install_deps (manifest, build_context, opt_install_deps_from, opt_user, opt_installation, &error))
+      if (!builder_manifest_install_deps (manifest, build_context, opt_install_deps_from, opt_user, opt_installation,
+                                          opt_yes, &error))
         {
           g_printerr ("Error running %s: %s\n", argv[3], error->message);
           return 1;

--- a/src/builder-manifest.c
+++ b/src/builder-manifest.c
@@ -3274,6 +3274,7 @@ builder_manifest_install_dep (BuilderManifest *self,
                               const char *opt_installation,
                               const char *runtime,
                               const char *version,
+                              gboolean opt_yes,
                               GError         **error)
 {
   g_autofree char *ref = NULL;
@@ -3305,6 +3306,9 @@ builder_manifest_install_dep (BuilderManifest *self,
       g_ptr_array_add (args, g_strdup (remote));
     }
 
+  if (opt_yes)
+    g_ptr_array_add (args, "-y");
+
   g_ptr_array_add (args, g_strdup (ref));
   g_ptr_array_add (args, NULL);
 
@@ -3322,6 +3326,7 @@ builder_manifest_install_extension_deps (BuilderManifest *self,
                                          const char *remote,
                                          gboolean opt_user,
                                          const char *opt_installation,
+                                         gboolean opt_yes,
                                          GError **error)
 {
   g_autofree char *runtime_ref = flatpak_build_runtime_ref (runtime, builder_manifest_get_runtime_version (self),
@@ -3368,6 +3373,7 @@ builder_manifest_install_extension_deps (BuilderManifest *self,
       g_print ("Dependency Extension: %s %s\n", runtime_extensions[i], extension_version);
       if (!builder_manifest_install_dep (self, context, remote, opt_user, opt_installation,
                                          runtime_extensions[i], extension_version,
+                                         opt_yes,
                                          error))
         return FALSE;
     }
@@ -3381,12 +3387,14 @@ builder_manifest_install_deps (BuilderManifest *self,
                                const char *remote,
                                gboolean opt_user,
                                const char *opt_installation,
+                               gboolean opt_yes,
                                GError **error)
 {
   /* Sdk */
   g_print ("Dependency Sdk: %s %s\n", self->sdk, builder_manifest_get_runtime_version (self));
   if (!builder_manifest_install_dep (self, context, remote, opt_user, opt_installation,
                                      self->sdk, builder_manifest_get_runtime_version (self),
+                                     opt_yes,
                                      error))
     return FALSE;
 
@@ -3394,6 +3402,7 @@ builder_manifest_install_deps (BuilderManifest *self,
   g_print ("Dependency Runtime: %s %s\n", self->runtime, builder_manifest_get_runtime_version (self));
   if (!builder_manifest_install_dep (self, context, remote, opt_user, opt_installation,
                                      self->runtime, builder_manifest_get_runtime_version (self),
+                                     opt_yes,
                                      error))
     return FALSE;
 
@@ -3402,6 +3411,7 @@ builder_manifest_install_deps (BuilderManifest *self,
       g_print ("Dependency Base: %s %s\n", self->base, builder_manifest_get_base_version (self));
       if (!builder_manifest_install_dep (self, context, remote, opt_user, opt_installation,
                                          self->base, builder_manifest_get_base_version (self),
+                                         opt_yes,
                                          error))
         return FALSE;
     }
@@ -3409,12 +3419,14 @@ builder_manifest_install_deps (BuilderManifest *self,
   if (!builder_manifest_install_extension_deps (self, context,
                                                 self->sdk, self->sdk_extensions,
                                                 remote,opt_user, opt_installation,
+                                                opt_yes,
                                                 error))
     return FALSE;
 
   if (!builder_manifest_install_extension_deps (self, context,
                                                 self->runtime, self->platform_extensions,
                                                 remote, opt_user, opt_installation,
+                                                opt_yes,
                                                 error))
     return FALSE;
 

--- a/src/builder-manifest.h
+++ b/src/builder-manifest.h
@@ -94,6 +94,7 @@ gboolean        builder_manifest_install_deps (BuilderManifest *self,
                                                const char *remote,
                                                gboolean opt_user,
                                                const char *opt_installation,
+                                               gboolean opt_yes,
                                                GError         **error);
 gboolean        builder_manifest_run (BuilderManifest *self,
                                       BuilderContext  *context,


### PR DESCRIPTION
This allows you to run --install-from-deps=foo -y to always install all
dependencies. Useful for auto-builders like flathub.