### PR TITLE
ccache: Enforce disabled if not enabled

### DIFF
--- a/src/builder-context.h
+++ b/src/builder-context.h
@@ -119,8 +119,9 @@ gboolean        builder_context_set_checksum_for (BuilderContext  *self,
 BuilderContext *builder_context_new (GFile *run_dir,
                                      GFile *app_dir,
                                      const char *state_subdir);
-gboolean        builder_context_enable_ccache (BuilderContext *self,
-                                               GError        **error);
+gboolean        builder_context_set_enable_ccache (BuilderContext *self,
+                                                   gboolean        enabled,
+                                                   GError        **error);
 gboolean        builder_context_enable_rofiles (BuilderContext *self,
                                                 GError        **error);
 gboolean        builder_context_disable_rofiles (BuilderContext *self,

--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -483,8 +483,7 @@ main (int    argc,
       builder_context_set_stop_at (build_context, opt_stop_at);
     }
 
-  if (opt_ccache &&
-      !builder_context_enable_ccache (build_context, &error))
+  if (!builder_context_set_enable_ccache (build_context, opt_ccache, &error))
     {
       g_printerr ("Can't initialize ccache use: %s\n", error->message);
       return 1;


### PR DESCRIPTION
This makes sure that ccache is disabled if you don't enable
it on the commandline. This makes sense, because we don't
have any persistant location for the ccache files anyway.

Additionally this is done to work around a race condition initializing
~/.ccache/ccache.conf that causes meson builds to error out.