### PR TITLE
Add --no-shallow-clone for git mirroring

### DIFF
--- a/doc/flatpak-builder.xml
+++ b/doc/flatpak-builder.xml
@@ -531,6 +531,14 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--no-shallow-clone</option></term>
+
+                <listitem><para>
+                  Don't use shallow clones when mirroring git repos.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--install-deps-from=REMOTE</option></term>
 
                 <listitem><para>

--- a/src/builder-context.c
+++ b/src/builder-context.c
@@ -77,6 +77,7 @@ struct BuilderContext
   gboolean        use_rofiles;
   gboolean        have_rofiles;
   gboolean        run_tests;
+  gboolean        no_shallow_clone;
 };
 
 typedef struct
@@ -859,6 +860,19 @@ builder_context_set_run_tests (BuilderContext *self,
                                gboolean run_tests)
 {
   self->run_tests = run_tests;
+}
+
+void
+builder_context_set_no_shallow_clone (BuilderContext *self,
+                                      gboolean        no_shallow_clone)
+{
+  self->no_shallow_clone = no_shallow_clone;
+}
+
+gboolean
+builder_context_get_no_shallow_clone (BuilderContext *self)
+{
+  return self->no_shallow_clone;
 }
 
 gboolean

--- a/src/builder-context.h
+++ b/src/builder-context.h
@@ -132,6 +132,9 @@ void            builder_context_set_use_rofiles (BuilderContext *self,
 gboolean        builder_context_get_run_tests (BuilderContext *self);
 void            builder_context_set_run_tests (BuilderContext *self,
                                                gboolean run_tests);
+void            builder_context_set_no_shallow_clone (BuilderContext *self,
+                                                      gboolean        no_shallow_clone);
+gboolean        builder_context_get_no_shallow_clone (BuilderContext *self);
 char **         builder_context_extend_env (BuilderContext *self,
                                             char          **envp);
 

--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -41,6 +41,7 @@ static gboolean opt_disable_cache;
 static gboolean opt_disable_tests;
 static gboolean opt_disable_rofiles;
 static gboolean opt_download_only;
+static gboolean opt_no_shallow_clone;
 static gboolean opt_bundle_sources;
 static gboolean opt_build_only;
 static gboolean opt_finish_only;
@@ -133,6 +134,7 @@ static GOptionEntry entries[] = {
   { "installation", 0, 0, G_OPTION_ARG_STRING, &opt_installation, "Install dependencies in a specific system-wide installation", "NAME" },
   { "state-dir", 0, 0, G_OPTION_ARG_FILENAME, &opt_state_dir, "Use this directory for state instead of .flatpak-builder", "PATH" },
   { "assumeyes", 'y', 0, G_OPTION_ARG_NONE, &opt_yes, N_("Automatically answer yes for all questions"), NULL },
+  { "no-shallow-clone", 0, 0, G_OPTION_ARG_NONE, &opt_no_shallow_clone, "Don't use shallow clones when mirroring git repos", NULL },
   { NULL }
 };
 
@@ -438,6 +440,7 @@ main (int    argc,
 
   builder_context_set_use_rofiles (build_context, !opt_disable_rofiles);
   builder_context_set_run_tests (build_context, !opt_disable_tests);
+  builder_context_set_no_shallow_clone (build_context, opt_no_shallow_clone);
   builder_context_set_keep_build_dirs (build_context, opt_keep_build_dirs);
   builder_context_set_delete_build_dirs (build_context, opt_delete_build_dirs);
   builder_context_set_sandboxed (build_context, opt_sandboxed);

--- a/src/builder-source-git.c
+++ b/src/builder-source-git.c
@@ -240,7 +240,7 @@ builder_source_git_download (BuilderSource  *source,
     flags |= FLATPAK_GIT_MIRROR_FLAGS_UPDATE;
   if (self->disable_fsckobjects)
     flags |= FLATPAK_GIT_MIRROR_FLAGS_DISABLE_FSCK;
-  if (self->disable_shallow_clone)
+  if (self->disable_shallow_clone || builder_context_get_no_shallow_clone (context))
     flags |= FLATPAK_GIT_MIRROR_FLAGS_DISABLE_SHALLOW;
   if (builder_context_get_bundle_sources (context))
     flags |= FLATPAK_GIT_MIRROR_FLAGS_WILL_FETCH_FROM;


### PR DESCRIPTION
This is useful e.g. when doing mirroring only, or if your git
has issues with shallow clones.