### PR TITLE
Add inherit-sdk-extensions property

### DIFF
--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -154,6 +154,11 @@
                     <listitem><para>Inherit these extra extensions points from the base application or sdk when
                     finishing the build.</para></listitem>
                 </varlistentry>
+                <varlistentry>
+                    <term><option>inherit-sd-extensions</option> (array of strings)</term>
+                    <listitem><para>Inherit these extra extensions points from the base application or sdk when
+                    finishing the build, but do not inherit them into the platform.</para></listitem>
+                </varlistentry>
 
                 <varlistentry>
                     <term><option>tags</option> (array of strings)</term>


### PR DESCRIPTION
This is similar to inherit-extensions, but the extensions
are not also inherited into the platform when it is created.