### PR TITLE
Fix --install to not pass --subpath= to flatpak install

### DIFF
--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -282,8 +282,6 @@ do_install (BuilderContext *build_context,
 
   g_ptr_array_add (args, g_strdup ("--reinstall"));
 
-  g_ptr_array_add (args, g_strdup ("--subpath="));
-
   ref = flatpak_build_untyped_ref (id, branch,
                                    builder_context_get_arch (build_context));
 


### PR DESCRIPTION
This isn't really right, as install doesn't handle an empty subpath
like that. In fact, doing so will break exports.