### PR TITLE
manifest: Add support for "extension-tag"

### DIFF
--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -73,6 +73,20 @@
                 </varlistentry>
                 -->
                 <varlistentry>
+                    <term><option>extension-tag</option> (string)</term>
+                    <listitem><para>If building an extension, the tag for the extension
+                    point to use. Since flatpak 0.11.4 a runtime may define multiple
+                    locations for the same extension point with the intention that
+                    different branches for the extension are mounted at each location. When
+                    building an extension it is necessary to know what extension point to
+                    install the extension to. This option resolves the any ambiguity
+                    in which extension point to choose. If not specified, the default choice
+                    is to install into either the only location for the extension point or
+                    into the location for the untagged extension point. If there are multiple
+                    locations for the same extension point defined with different tags
+                    then an error will occurr.</para></listitem>
+                </varlistentry>
+                <varlistentry>
                     <term><option>runtime</option> (string)</term>
                     <listitem><para>The name of the runtime that the application uses.</para></listitem>
                 </varlistentry>

--- a/src/builder-manifest.h
+++ b/src/builder-manifest.h
@@ -62,6 +62,7 @@ const char *    builder_manifest_get_branch (BuilderManifest *self);
 void            builder_manifest_set_default_branch (BuilderManifest *self,
                                                      const char *default_branch);
 const char *    builder_manifest_get_collection_id (BuilderManifest *self);
+const char *    builder_manifest_get_extension_tag (BuilderManifest *self);
 void            builder_manifest_set_default_collection_id (BuilderManifest *self,
                                                             const char      *default_collection_id);
 


### PR DESCRIPTION
This passes an --extension-tag to flatpak build-init which will
set the "tag" option on the ExtensionOf section in the metadata.