### PR TITLE
Add YAML support as an alternative to JSON

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -10,7 +10,7 @@ pkg_install sudo which attr fuse \
     libubsan libasan libtsan elfutils-libelf-devel libdwarf-devel \
     elfutils git gettext-devel libappstream-glib-devel \
     /usr/bin/{update-mime-database,update-desktop-database,gtk-update-icon-cache}
-pkg_install_testing ostree-devel ostree
+pkg_install_testing ostree-devel ostree libyaml-devel
 pkg_install_if_os fedora gjs parallel clang
 pkg_install_builddeps flatpak
 

--- a/configure.ac
+++ b/configure.ac
@@ -146,6 +146,17 @@ AS_IF([test "x$with_dwarf_header" = "xyes"],
        AS_IF([test "x$ac_cv_header_dwarf_h" != "xyes"],
              [AC_MSG_ERROR([dwarf.h is required but was not found])])])
 
+AC_ARG_WITH([yaml],
+  [AS_HELP_STRING([--without-yaml],
+                  [Disable YAML support [default=auto]])])
+AS_IF([test "x$with_yaml" != "xno"],[
+  PKG_CHECK_MODULES(YAML, [yaml-0.1], [have_yaml=yes], [have_yaml])
+], [have_yaml=no])
+AS_IF([test "x$have_yaml" = "xno"],[
+  AS_IF([test "x$with_yaml" = "xyes"],
+        [AC_MSG_ERROR([yaml-0.1 was not found, which is needed for --with-yaml])])
+], [YAML_CFLAGS="$YAML_CFLAGS -DFLATPAK_BUILDER_ENABLE_YAML"])
+
 # Do we enable building peer to peer support using libostree’s experimental (non-stable) API?
 # If so, OSTREE_ENABLE_EXPERIMENTAL_API needs to be #defined before ostree.h is
 # included.

--- a/configure.ac
+++ b/configure.ac
@@ -150,12 +150,12 @@ AC_ARG_WITH([yaml],
   [AS_HELP_STRING([--without-yaml],
                   [Disable YAML support [default=auto]])])
 AS_IF([test "x$with_yaml" != "xno"],[
-  PKG_CHECK_MODULES(YAML, [yaml-0.1], [have_yaml=yes], [have_yaml])
+  PKG_CHECK_MODULES(YAML, [yaml-0.1], [have_yaml=yes], [have_yaml=no])
 ], [have_yaml=no])
 AS_IF([test "x$have_yaml" = "xno"],[
   AS_IF([test "x$with_yaml" = "xyes"],
         [AC_MSG_ERROR([yaml-0.1 was not found, which is needed for --with-yaml])])
-], [YAML_CFLAGS="$YAML_CFLAGS -DFLATPAK_BUILDER_ENABLE_YAML"])
+], [AC_DEFINE([FLATPAK_BUILDER_ENABLE_YAML],[1],[Define if yaml supported])])
 
 # Do we enable building peer to peer support using libostree’s experimental (non-stable) API?
 # If so, OSTREE_ENABLE_EXPERIMENTAL_API needs to be #defined before ostree.h is

--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -44,5 +44,5 @@ flatpak_builder_SOURCES = \
 	src/builder-git.h \
 	$(NULL)
 
-flatpak_builder_LDADD = $(AM_LDADD) $(BASE_LIBS) $(LIBELF_LIBS) libglnx.la
-flatpak_builder_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS)
+flatpak_builder_LDADD = $(AM_LDADD) $(BASE_LIBS) $(LIBELF_LIBS) $(YAML_LIBS) libglnx.la
+flatpak_builder_CFLAGS = $(AM_CFLAGS) $(BASE_CFLAGS) $(YAML_CFLAGS)

--- a/src/builder-manifest.c
+++ b/src/builder-manifest.c
@@ -1117,15 +1117,15 @@ builder_manifest_deserialize_property (JsonSerializable *serializable,
                   g_autoptr(GFile) module_file =
                     g_file_resolve_relative_path (demarshal_base_dir, module_relpath);
                   const char *module_path = flatpak_file_get_path_cached (module_file);
-                  g_autofree char *json = NULL;
+                  g_autofree char *module_contents = NULL;
                   g_autoptr(GError) error = NULL;
 
-                  if (g_file_get_contents (module_path, &json, NULL, &error))
+                  if (g_file_get_contents (module_path, &module_contents, NULL, &error))
                     {
                       g_autoptr(GFile) module_file_dir = g_file_get_parent (module_file);
                       builder_manifest_set_demarshal_base_dir (module_file_dir);
-                      module = json_gobject_from_data (BUILDER_TYPE_MODULE,
-                                                       json, -1, &error);
+                      module = builder_gobject_from_data (BUILDER_TYPE_MODULE,
+                                                          module_relpath, module_contents, &error);
                       builder_manifest_set_demarshal_base_dir (saved_demarshal_base_dir);
                       if (module)
                         {

--- a/src/builder-module.c
+++ b/src/builder-module.c
@@ -824,14 +824,14 @@ builder_module_deserialize_property (JsonSerializable *serializable,
                   g_autoptr(GFile) module_file =
                     g_file_resolve_relative_path (saved_demarshal_base_dir, module_relpath);
                   const char *module_path = flatpak_file_get_path_cached (module_file);
-                  g_autofree char *json = NULL;
+                  g_autofree char *module_contents = NULL;
 
-                  if (g_file_get_contents (module_path, &json, NULL, NULL))
+                  if (g_file_get_contents (module_path, &module_contents, NULL, NULL))
                     {
                       g_autoptr(GFile) module_file_dir = g_file_get_parent (module_file);
                       builder_manifest_set_demarshal_base_dir (module_file_dir);
-                      module = json_gobject_from_data (BUILDER_TYPE_MODULE,
-                                                       json, -1, NULL);
+                      module = builder_gobject_from_data (BUILDER_TYPE_MODULE,
+                                                          module_relpath, module_contents, NULL);
                       builder_manifest_set_demarshal_base_dir (saved_demarshal_base_dir);
                       if (module)
                         {

--- a/src/builder-utils.h
+++ b/src/builder-utils.h
@@ -61,6 +61,14 @@ void     flatpak_collect_matches_for_path_pattern (const char *path,
 gboolean builder_migrate_locale_dirs (GFile   *root_dir,
                                       GError **error);
 
+GQuark builder_yaml_parse_error_quark (void);
+#define BUILDER_YAML_PARSE_ERROR (builder_yaml_parse_error_quark ())
+
+GObject * builder_gobject_from_data (GType       gtype,
+                                     const char *relpath,
+                                     const char *contents,
+                                     GError    **error);
+
 gboolean builder_host_spawnv (GFile                *dir,
                               char                **output,
                               GSubprocessFlags      flags,

--- a/tests/module1.yaml
+++ b/tests/module1.yaml
@@ -1,0 +1,14 @@
+name: module1
+modules:
+  - name: module1-first
+    buildsystem: simple
+    build-commands:
+      - 'echo module1 > /app/ran_module1'
+      - 'echo module1 > /app/modify_me'
+    sources:
+      - type: file
+        path: data1
+      - type: patch
+        strip-components: 0
+        path: data1.patch
+  - include2/module2.yaml

--- a/tests/module2.yaml
+++ b/tests/module2.yaml
@@ -1,0 +1,11 @@
+name: module2
+buildsystem: simple
+ensure-writable: [ /modify_me ]
+build-commands:
+  - 'echo module2 > /app/ran_module2'
+  - 'echo module2 > /app/modify_me'
+sources:
+  - type: file
+    path: data2
+  - type: patch
+    path: data2.patch

--- a/tests/test-builder.sh
+++ b/tests/test-builder.sh
@@ -37,17 +37,21 @@ cd $TEST_DATA_DIR/
 cp -a $(dirname $0)/test-configure .
 echo "version1" > app-data
 cp $(dirname $0)/test.json .
+cp $(dirname $0)/test.yaml .
 cp $(dirname $0)/test-runtime.json .
 cp $(dirname $0)/0001-Add-test-logo.patch .
 mkdir include1
 cp $(dirname $0)/module1.json include1/
+cp $(dirname $0)/module1.yaml include1/
 cp $(dirname $0)/data1 include1/
 cp $(dirname $0)/data1.patch include1/
 mkdir include1/include2
 cp $(dirname $0)/module2.json include1/include2/
+cp $(dirname $0)/module2.yaml include1/include2/
 cp $(dirname $0)/data2 include1/include2/
 cp $(dirname $0)/data2.patch include1/include2/
 ${FLATPAK_BUILDER} --repo=$REPO $FL_GPGARGS --force-clean appdir test.json
+${FLATPAK_BUILDER} --repo=$REPO $FL_GPGARGS --force-clean appdir test.yaml
 
 assert_file_has_content appdir/files/share/app-data version1
 assert_file_has_content appdir/metadata shared=network;
@@ -80,6 +84,8 @@ echo "ok install+run"
 
 echo "version2" > app-data
 ${FLATPAK_BUILDER} $FL_GPGARGS --repo=$REPO --force-clean appdir test.json
+assert_file_has_content appdir/files/share/app-data version2
+${FLATPAK_BUILDER} $FL_GPGARGS --repo=$REPO --force-clean appdir test.yaml
 assert_file_has_content appdir/files/share/app-data version2
 
 ${FLATPAK} ${U} update org.test.Hello2 master

--- a/tests/test.yaml
+++ b/tests/test.yaml
@@ -1,0 +1,52 @@
+app-id: org.test.Hello2
+runtime: org.test.Platform
+sdk: org.test.Sdk
+command: hello2.sh
+tags: [test]
+finish-args:
+  - --share=network
+build-options:
+  cflags: -O2 -g
+  cxxflags: -O2 -g
+  env:
+    FOO: bar
+    V: '1'
+cleanup: [/cleanup, '*.cleanup']
+cleanup-commands: [touch /app/cleaned_up]
+modules:
+  - include1/module1.yaml
+  - name: root
+    modules:
+      - name: test
+        config-opts: [--some-arg]
+        post-install:
+          - touch /app/bin/file.cleanup
+          - mkdir -p /app/share/icons/
+          - cp org.test.Hello.png /app/share/icons/
+        make-args: [BAR=2]
+        make-install-args: [BAR=3]
+        build-commands: ['echo foo > /app/out']
+        sources:
+          - type: file
+            path: test-configure
+            dest-filename: configure
+            sha256: 675a1ac2feec4d4f54e581b4b01bc3cfd2c1cf31aa5963574d31228c8a11b7e7
+          - type: file
+            path: app-data
+          - type: script
+            dest-filename: hello2.sh
+            commands: ['echo "Hello world2, from a sandbox"']
+          - type: shell
+            commands:
+              - mkdir /app/cleanup/
+              - touch /app/cleanup/a_file
+          - type: patch
+            path: 0001-Add-test-logo.patch
+            use-git: true
+      - name: test2
+        build-commands: ['echo foo2 > /app/out2']
+        buildsystem: simple
+        sources:
+          - type: file
+            path: app-data
+      - name: empty


### PR DESCRIPTION
Closes #2.

Some notes:

- Rather than rebuilding the entire deserialization logic, I simply converted the YAML tree to `JsonNode`s. The advantage is this is far less intrusive, and it piggyback's on json-glib's already-present, battle-tested deserialization logic.
- libyaml is present all the way back to CentOS/RHEL 6 and Ubuntu 14.04. (On the two RH distros, libyaml-devel is in the optional repos, though it seems most \*-devel files are in there as well.)
- That being said, since there was still concern in #2 about portability, I put it behind an autoconf switch. By default, it'll automatically check for libyaml, and enable it if found; it can be forcibly enabled via `--with-yaml` or disabled via `--without-yaml`.

You can just look at the new tests to see the big difference in readability and conciseness in YAML vs JSON, and all for a 124KB shared library. :wink: 