### PR TITLE
Add directory source

### DIFF
--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -684,6 +684,23 @@
                 </variablelist>
             </refsect3>
             <refsect3>
+                <title>Directory sources</title>
+                <variablelist>
+                    <varlistentry>
+                        <term><option>type</option></term>
+                        <listitem><para>"dir"</para></listitem>
+                    </varlistentry>
+                    <varlistentry>
+                        <term><option>path</option> (string)</term>
+                        <listitem><para>The path of a local directory whose content will be copied into the source dir. Note that directory sources don't currently support caching, so they will be rebuilt each time.</para></listitem>
+                    </varlistentry>
+                    <varlistentry>
+                        <term><option>skip</option> (array of string)</term>
+                        <listitem><para>Source files to ignore in the directory.</para></listitem>
+                    </varlistentry>
+                </variablelist>
+            </refsect3>
+            <refsect3>
                 <title>File sources</title>
                 <variablelist>
                     <varlistentry>

--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -34,6 +34,8 @@ flatpak_builder_SOURCES = \
 	src/builder-source-extra-data.h \
 	src/builder-source-patch.c \
 	src/builder-source-patch.h \
+	src/builder-source-dir.c \
+	src/builder-source-dir.h \
 	src/builder-context.c \
 	src/builder-context.h \
 	src/builder-cache.c \

--- a/src/builder-cache.c
+++ b/src/builder-cache.c
@@ -1337,6 +1337,13 @@ builder_cache_checksum_uint32 (BuilderCache *self,
 }
 
 void
+builder_cache_checksum_random (BuilderCache *self)
+{
+  builder_cache_checksum_uint32 (self, g_random_int ());
+  builder_cache_checksum_uint32 (self, g_random_int ());
+}
+
+void
 builder_cache_checksum_uint64 (BuilderCache *self,
                                guint64       val)
 {

--- a/src/builder-cache.h
+++ b/src/builder-cache.h
@@ -80,6 +80,7 @@ void builder_cache_checksum_uint64 (BuilderCache *self,
 void builder_cache_checksum_data (BuilderCache *self,
                                   guint8       *data,
                                   gsize         len);
+void builder_cache_checksum_random (BuilderCache *self);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (BuilderCache, g_object_unref)
 

--- a/src/builder-flatpak-utils.h
+++ b/src/builder-flatpak-utils.h
@@ -245,6 +245,7 @@ typedef enum {
 gboolean   flatpak_cp_a (GFile         *src,
                          GFile         *dest,
                          FlatpakCpFlags flags,
+                         GPtrArray     *skip_files,
                          GCancellable  *cancellable,
                          GError       **error);
 

--- a/src/builder-source-dir.c
+++ b/src/builder-source-dir.c
@@ -1,0 +1,305 @@
+/* builder-source-dir.c
+ *
+ * Copyright (C) 2015 Red Hat, Inc
+ *
+ * This file is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This file is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Alexander Larsson <alexl@redhat.com>
+ */
+
+#include "config.h"
+
+#include <string.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/statfs.h>
+
+#include "builder-flatpak-utils.h"
+
+#include "builder-utils.h"
+#include "builder-source-dir.h"
+
+struct BuilderSourceDir
+{
+  BuilderSource parent;
+
+  char         *path;
+  char        **skip;
+};
+
+typedef struct
+{
+  BuilderSourceClass parent_class;
+} BuilderSourceDirClass;
+
+G_DEFINE_TYPE (BuilderSourceDir, builder_source_dir, BUILDER_TYPE_SOURCE);
+
+enum {
+  PROP_0,
+  PROP_PATH,
+  PROP_SKIP,
+  LAST_PROP
+};
+
+static void
+builder_source_dir_finalize (GObject *object)
+{
+  BuilderSourceDir *self = (BuilderSourceDir *) object;
+
+  g_free (self->path);
+  g_strfreev (self->skip);
+
+  G_OBJECT_CLASS (builder_source_dir_parent_class)->finalize (object);
+}
+
+static void
+builder_source_dir_get_property (GObject    *object,
+                                 guint       prop_id,
+                                 GValue     *value,
+                                 GParamSpec *pspec)
+{
+  BuilderSourceDir *self = BUILDER_SOURCE_DIR (object);
+
+  switch (prop_id)
+    {
+    case PROP_PATH:
+      g_value_set_string (value, self->path);
+      break;
+
+    case PROP_SKIP:
+      g_value_set_boxed (value, self->skip);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+builder_source_dir_set_property (GObject      *object,
+                                 guint         prop_id,
+                                 const GValue *value,
+                                 GParamSpec   *pspec)
+{
+  BuilderSourceDir *self = BUILDER_SOURCE_DIR (object);
+  gchar **tmp;
+
+  switch (prop_id)
+    {
+    case PROP_PATH:
+      g_free (self->path);
+      self->path = g_value_dup_string (value);
+      break;
+
+    case PROP_SKIP:
+      tmp = self->skip;
+      self->skip = g_strdupv (g_value_get_boxed (value));
+      g_strfreev (tmp);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static GFile *
+get_source_file (BuilderSourceDir *self,
+                 BuilderContext    *context,
+                 GError           **error)
+{
+  GFile *base_dir = BUILDER_SOURCE (self)->base_dir;
+
+  if (self->path != NULL && self->path[0] != 0)
+    {
+      return g_file_resolve_relative_path (base_dir, self->path);
+    }
+
+  g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "source dir path not specified");
+  return NULL;
+}
+
+static gboolean
+builder_source_dir_show_deps (BuilderSource  *source,
+                              GError        **error)
+{
+  BuilderSourceDir *self = BUILDER_SOURCE_DIR (source);
+
+  if (self->path && self->path[0] != 0)
+    g_print ("%s\n", self->path);
+
+  return TRUE;
+}
+
+static gboolean
+builder_source_dir_download (BuilderSource  *source,
+                             gboolean        update_vcs,
+                             BuilderContext *context,
+                             GError        **error)
+{
+  BuilderSourceDir *self = BUILDER_SOURCE_DIR (source);
+  g_autoptr(GFile) file = NULL;
+
+  file = get_source_file (self, context, error);
+  if (file == NULL)
+    return FALSE;
+
+  if (g_file_query_file_type (file, G_FILE_QUERY_INFO_NONE, NULL) != G_FILE_TYPE_DIRECTORY)
+    return flatpak_fail (error, "Can't find directory at %s", self->path);
+
+  return TRUE;
+}
+
+static GPtrArray *
+builder_source_dir_get_skip (BuilderSource  *source,
+                             BuilderContext *context)
+{
+  BuilderSourceDir *self = BUILDER_SOURCE_DIR (source);
+  g_autoptr(GPtrArray) skip = g_ptr_array_new_with_free_func (g_object_unref);
+  int i;
+
+  g_ptr_array_add (skip, g_object_ref (builder_context_get_app_dir_raw (context)));
+  g_ptr_array_add (skip, g_object_ref (builder_context_get_state_dir (context)));
+
+  if (self->skip)
+    {
+      g_autoptr(GFile) source_dir = get_source_file (self, context, NULL);
+
+      for (i = 0; source_dir != NULL && self->skip[i] != NULL; i++)
+        {
+          GFile *f = g_file_resolve_relative_path (source_dir, self->skip[i]);
+          if (f)
+            g_ptr_array_add (skip, f);
+        }
+    }
+
+  return g_steal_pointer (&skip);
+}
+
+static gboolean
+builder_source_dir_extract (BuilderSource  *source,
+                            GFile          *dest,
+                            BuilderOptions *build_options,
+                            BuilderContext *context,
+                            GError        **error)
+{
+  BuilderSourceDir *self = BUILDER_SOURCE_DIR (source);
+  g_autoptr(GFile) src = NULL;
+  g_autoptr(GPtrArray) skip = NULL;
+
+  src = get_source_file (self, context, error);
+  if (src == NULL)
+    return FALSE;
+
+  skip = builder_source_dir_get_skip (source, context);
+  g_mkdir_with_parents (flatpak_file_get_path_cached (src), 0755);
+  if (!flatpak_cp_a (src, dest,
+                     FLATPAK_CP_FLAGS_MERGE|FLATPAK_CP_FLAGS_NO_CHOWN,
+                     skip, NULL, error))
+    return FALSE;
+
+  return TRUE;
+}
+
+static gboolean
+builder_source_dir_bundle (BuilderSource  *source,
+                            BuilderContext *context,
+                            GError        **error)
+{
+  BuilderSourceDir *self = BUILDER_SOURCE_DIR (source);
+  g_autoptr(GFile) src = NULL;
+  g_autoptr(GFile) dest = NULL;
+  GFile *manifest_base_dir = builder_context_get_base_dir (context);
+  g_autofree char *rel_path = NULL;
+  g_autoptr(GPtrArray) skip = NULL;
+
+  src = get_source_file (self, context, error);
+  if (src == NULL)
+    return FALSE;
+
+  rel_path = g_file_get_relative_path (manifest_base_dir, src);
+  if (rel_path == NULL)
+    {
+      g_warning ("Local file %s is outside manifest tree, not bundling", flatpak_file_get_path_cached (src));
+      return TRUE;
+    }
+
+  dest = flatpak_build_file (builder_context_get_app_dir (context),
+                             "sources/manifest", rel_path, NULL);
+
+  skip = builder_source_dir_get_skip (source, context);
+  g_mkdir_with_parents (flatpak_file_get_path_cached (dest), 0755);
+  if (!flatpak_cp_a (src, dest,
+                     FLATPAK_CP_FLAGS_MERGE|FLATPAK_CP_FLAGS_NO_CHOWN,
+                     skip, NULL, error))
+    return FALSE;
+
+  return TRUE;
+}
+
+static gboolean
+builder_source_dir_update (BuilderSource  *source,
+                            BuilderContext *context,
+                            GError        **error)
+{
+  return TRUE;
+}
+
+static void
+builder_source_dir_checksum (BuilderSource  *source,
+                              BuilderCache   *cache,
+                              BuilderContext *context)
+{
+  /* We can't realistically checksum a directory, so always rebuild */
+  builder_cache_checksum_random (cache);
+}
+
+static void
+builder_source_dir_class_init (BuilderSourceDirClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  BuilderSourceClass *source_class = BUILDER_SOURCE_CLASS (klass);
+
+  object_class->finalize = builder_source_dir_finalize;
+  object_class->get_property = builder_source_dir_get_property;
+  object_class->set_property = builder_source_dir_set_property;
+
+  source_class->show_deps = builder_source_dir_show_deps;
+  source_class->download = builder_source_dir_download;
+  source_class->extract = builder_source_dir_extract;
+  source_class->bundle = builder_source_dir_bundle;
+  source_class->update = builder_source_dir_update;
+  source_class->checksum = builder_source_dir_checksum;
+
+  g_object_class_install_property (object_class,
+                                   PROP_PATH,
+                                   g_param_spec_string ("path",
+                                                        "",
+                                                        "",
+                                                        NULL,
+                                                        G_PARAM_READWRITE));
+  g_object_class_install_property (object_class,
+                                   PROP_SKIP,
+                                   g_param_spec_boxed ("skip",
+                                                       "",
+                                                       "",
+                                                       G_TYPE_STRV,
+                                                       G_PARAM_READWRITE));
+}
+
+static void
+builder_source_dir_init (BuilderSourceDir *self)
+{
+}

--- a/src/builder-source-dir.h
+++ b/src/builder-source-dir.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Alexander Larsson <alexl@redhat.com>
+ */
+
+#ifndef __BUILDER_SOURCE_DIR_H__
+#define __BUILDER_SOURCE_DIR_H__
+
+#include "builder-source.h"
+
+G_BEGIN_DECLS
+
+typedef struct BuilderSourceDir BuilderSourceDir;
+
+#define BUILDER_TYPE_SOURCE_DIR (builder_source_dir_get_type ())
+#define BUILDER_SOURCE_DIR(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), BUILDER_TYPE_SOURCE_DIR, BuilderSourceDir))
+#define BUILDER_IS_SOURCE_DIR(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), BUILDER_TYPE_SOURCE_DIR))
+
+GType builder_source_dir_get_type (void);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (BuilderSourceDir, g_object_unref)
+
+G_END_DECLS
+
+#endif /* __BUILDER_SOURCE_DIR_H__ */

--- a/src/builder-source.c
+++ b/src/builder-source.c
@@ -35,6 +35,7 @@
 #include "builder-source-bzr.h"
 #include "builder-source-svn.h"
 #include "builder-source-file.h"
+#include "builder-source-dir.h"
 #include "builder-source-script.h"
 #include "builder-source-shell.h"
 #include "builder-source-extra-data.h"
@@ -250,6 +251,8 @@ builder_source_to_json (BuilderSource *self)
     type = "archive";
   else if (BUILDER_IS_SOURCE_FILE (self))
     type = "file";
+  else if (BUILDER_IS_SOURCE_DIR (self))
+    type = "dir";
   else if (BUILDER_IS_SOURCE_SCRIPT (self))
     type = "script";
   else if (BUILDER_IS_SOURCE_SHELL (self))
@@ -287,6 +290,8 @@ builder_source_from_json (JsonNode *node)
     return (BuilderSource *) json_gobject_deserialize (BUILDER_TYPE_SOURCE_ARCHIVE, node);
   else if (strcmp (type, "file") == 0)
     return (BuilderSource *) json_gobject_deserialize (BUILDER_TYPE_SOURCE_FILE, node);
+  else if (strcmp (type, "dir") == 0)
+    return (BuilderSource *) json_gobject_deserialize (BUILDER_TYPE_SOURCE_DIR, node);
   else if (strcmp (type, "script") == 0)
     return (BuilderSource *) json_gobject_deserialize (BUILDER_TYPE_SOURCE_SCRIPT, node);
   else if (strcmp (type, "shell") == 0)

--- a/src/builder-utils.c
+++ b/src/builder-utils.c
@@ -334,7 +334,7 @@ migrate_locale_dir (GFile      *source_dir,
 
           if (!flatpak_cp_a (child, locale_subdir,
                              FLATPAK_CP_FLAGS_MERGE | FLATPAK_CP_FLAGS_MOVE,
-                             NULL, error))
+                             NULL, NULL, error))
             return FALSE;
 
           target = g_build_filename ("../../share/runtime/locale", relative, NULL);


### PR DESCRIPTION
This adds a source type that copies an entire directory, optionally skipping some files. Additionally it also skips the .flatpak-directory dir and the build dir to avoid weird recursion.

Since we can't really checksum an entire directory a dir source is always rebuilt.

@matthiasclasen you were interested in this, right?