### PR TITLE
When using --download-only skip some checks

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -8,7 +8,7 @@ dn=$(dirname $0)
 
 pkg_install sudo which attr fuse \
     libubsan libasan libtsan elfutils-libelf-devel libdwarf-devel \
-    elfutils git gettext-devel libappstream-glib-devel \
+    elfutils git gettext-devel libappstream-glib-devel bison \
     /usr/bin/{update-mime-database,update-desktop-database,gtk-update-icon-cache}
 pkg_install_testing ostree-devel ostree libyaml-devel
 pkg_install_if_os fedora gjs parallel clang

--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -667,20 +667,21 @@ main (int    argc,
     }
 
   /* Verify that cache and build dir is on same filesystem */
-  {
-    g_autofree char *state_path = g_file_get_path (builder_context_get_state_dir (build_context));
-    g_autoptr(GFile) app_parent = g_file_get_parent (builder_context_get_app_dir (build_context));
-    g_autofree char *app_parent_path = g_file_get_path (app_parent);
-    struct stat buf1, buf2;
+  if (!opt_download_only)
+    {
+      g_autofree char *state_path = g_file_get_path (builder_context_get_state_dir (build_context));
+      g_autoptr(GFile) app_parent = g_file_get_parent (builder_context_get_app_dir (build_context));
+      g_autofree char *app_parent_path = g_file_get_path (app_parent);
+      struct stat buf1, buf2;
 
-    if (stat (app_parent_path, &buf1) == 0 && stat (state_path, &buf2) == 0 &&
-        buf1.st_dev != buf2.st_dev)
-      {
-        g_printerr ("The state dir (%s) is not on the same filesystem as the target dir (%s)\n",
-                    state_path, app_parent_path);
-        return 1;
-      }
-  }
+      if (stat (app_parent_path, &buf1) == 0 && stat (state_path, &buf2) == 0 &&
+          buf1.st_dev != buf2.st_dev)
+        {
+          g_printerr ("The state dir (%s) is not on the same filesystem as the target dir (%s)\n",
+                      state_path, app_parent_path);
+          return 1;
+        }
+    }
 
   if (!builder_context_set_checksum_for (build_context, manifest_basename, manifest_sha256, &error))
     {
@@ -688,7 +689,7 @@ main (int    argc,
       return 1;
     }
 
-  if (!builder_manifest_start (manifest, opt_allow_missing_runtimes, build_context, &error))
+  if (!builder_manifest_start (manifest, opt_download_only, opt_allow_missing_runtimes, build_context, &error))
     {
       g_printerr ("Failed to init: %s\n", error->message);
       return 1;

--- a/src/builder-manifest.c
+++ b/src/builder-manifest.c
@@ -1465,6 +1465,7 @@ flatpak_info (gboolean opt_user,
 
 gboolean
 builder_manifest_start (BuilderManifest *self,
+                        gboolean download_only,
                         gboolean allow_missing_runtimes,
                         BuilderContext  *context,
                         GError         **error)
@@ -1484,14 +1485,14 @@ builder_manifest_start (BuilderManifest *self,
 
   self->sdk_commit = flatpak (NULL, "info", arch_option, "--show-commit", self->sdk,
                               builder_manifest_get_runtime_version (self), NULL);
-  if (!allow_missing_runtimes && self->sdk_commit == NULL)
+  if (!download_only && !allow_missing_runtimes && self->sdk_commit == NULL)
     return flatpak_fail (error, "Unable to find sdk %s version %s",
                          self->sdk,
                          builder_manifest_get_runtime_version (self));
 
   self->runtime_commit = flatpak (NULL, "info", arch_option, "--show-commit", self->runtime,
                                   builder_manifest_get_runtime_version (self), NULL);
-  if (!allow_missing_runtimes && self->runtime_commit == NULL)
+  if (!download_only && !allow_missing_runtimes && self->runtime_commit == NULL)
     return flatpak_fail (error, "Unable to find runtime %s version %s",
                          self->runtime,
                          builder_manifest_get_runtime_version (self));
@@ -1500,7 +1501,7 @@ builder_manifest_start (BuilderManifest *self,
     {
       self->base_commit = flatpak (NULL, "info", arch_option, "--show-commit", self->base,
                                    builder_manifest_get_base_version (self), NULL);
-      if (self->base_commit == NULL)
+      if (!download_only && self->base_commit == NULL)
         return flatpak_fail (error, "Unable to find app %s version %s",
                              self->base, builder_manifest_get_base_version (self));
     }

--- a/src/builder-manifest.h
+++ b/src/builder-manifest.h
@@ -71,6 +71,7 @@ void            builder_manifest_set_default_collection_id (BuilderManifest *sel
 char **         builder_manifest_get_exclude_dirs (BuilderManifest *self);
 
 gboolean        builder_manifest_start (BuilderManifest *self,
+                                        gboolean         download_only,
                                         gboolean         allow_missing_runtimes,
                                         BuilderContext  *context,
                                         GError         **error);


### PR DESCRIPTION
When downloading only we will not be building, so we can skip all the checks for dependencies
and for the state-dir properties.