### PR TITLE
Fix extra-data size type in manifest manpage

### DIFF
--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -827,7 +827,7 @@
                         <listitem><para>The sha256 of the extra data.</para></listitem>
                     </varlistentry>
                     <varlistentry>
-                        <term><option>size</option> (string)</term>
+                        <term><option>size</option> (number)</term>
                         <listitem><para>The size of the extra data.</para></listitem>
                     </varlistentry>
                     <varlistentry>


### PR DESCRIPTION
At least as of 0.10.10, this needs to be a number.