### PR TITLE
Use libcurl for HTTP downloads as well

### DIFF
--- a/src/builder-context.c
+++ b/src/builder-context.c
@@ -391,13 +391,11 @@ builder_context_download_uri (BuilderContext *self,
           if (builder_download_uri (mirror_uri,
                                     dest,
                                     checksums, checksums_type,
-                                    builder_context_get_soup_session (self),
                                     builder_context_get_curl_session (self),
                                     &my_error))
             return TRUE;
 
-          if (!g_error_matches (my_error, SOUP_HTTP_ERROR, SOUP_STATUS_NOT_FOUND) &&
-              !g_error_matches (my_error, BUILDER_CURL_ERROR, CURLE_REMOTE_FILE_NOT_FOUND))
+          if (!g_error_matches (my_error, BUILDER_CURL_ERROR, CURLE_REMOTE_FILE_NOT_FOUND))
             g_warning ("Error downloading from mirror: %s\n", my_error->message);
         }
     }
@@ -405,7 +403,6 @@ builder_context_download_uri (BuilderContext *self,
   if (!builder_download_uri (original_uri,
                              dest,
                              checksums, checksums_type,
-                             builder_context_get_soup_session (self),
                              builder_context_get_curl_session (self),
                              error))
     return FALSE;

--- a/src/builder-flatpak-utils.c
+++ b/src/builder-flatpak-utils.c
@@ -1242,6 +1242,8 @@ flatpak_create_curl_session (const char *user_agent)
     return NULL;
 
   curl_easy_setopt (curl_session, CURLOPT_CONNECTTIMEOUT, 60);
+  curl_easy_setopt (curl_session, CURLOPT_FOLLOWLOCATION, 1);
+  curl_easy_setopt (curl_session, CURLOPT_MAXREDIRS, 50);
   curl_easy_setopt (curl_session, CURLOPT_NOPROGRESS, 0);
   curl_easy_setopt (curl_session, CURLOPT_USERAGENT, user_agent);
 

--- a/src/builder-utils.h
+++ b/src/builder-utils.h
@@ -88,7 +88,6 @@ gboolean builder_download_uri (SoupURI        *uri,
                                GFile          *dest,
                                const char     *checksums[BUILDER_CHECKSUMS_LEN],
                                GChecksumType   checksums_type[BUILDER_CHECKSUMS_LEN],
-                               SoupSession    *soup_session,
                                CURL           *curl_session,
                                GError        **error);
 


### PR DESCRIPTION
As discussed in #143, drop libsoup support for source download and use libcurl instead so that we can benefit of libcurl features like HTTP2 support.

By the way, it brings a fancy progress bar for downloads.