### PR TITLE
Work around libsoup type initialization deadlocks

### DIFF
--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -355,6 +355,15 @@ main (int    argc,
   else
     g_unsetenv ("GIO_USE_VFS");
 
+
+  /* Work around libsoup/glib race condition, as per:
+     https://bugzilla.gnome.org/show_bug.cgi?id=796031 and
+     https://bugzilla.gnome.org/show_bug.cgi?id=674885#c87 */
+  g_type_ensure (G_TYPE_SOCKET_FAMILY);
+  g_type_ensure (G_TYPE_SOCKET_TYPE);
+  g_type_ensure (G_TYPE_SOCKET_PROTOCOL);
+  g_type_ensure (G_TYPE_SOCKET_ADDRESS);
+
   orig_argv = g_memdup (argv, sizeof (char *) * argc);
   orig_argc = argc;
 


### PR DESCRIPTION
As reported in
https://bugzilla.gnome.org/show_bug.cgi?id=796031#c1
we sometimes hang in libsoup downloading stuff. This uses
an early type initialization to avoid that.

We don't use libsoup for the main download anymore, but
its still used for some things, so better safe than sorry.