### PR TITLE
Expand on what a command is for simple buildsystem

### DIFF
--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -509,6 +509,7 @@
                     <term><option>build-commands</option> (array of strings)</term>
                     <listitem><para>An array of commands to run during build (between make and make install if those are used).
                     This is primarily useful when using the "simple" buildsystem.
+                    Each command is run in <literal>/bin/sh -c</literal>, so it can use standard POSIX shell syntax such as piping output.
                     </para></listitem>
                 </varlistentry>
                 <varlistentry>


### PR DESCRIPTION
It wasn't obvious to me what a command was - whether it was run through a shell or separated into an argument list to be invoked directly. Looking at [the source code](https://github.com/flatpak/flatpak-builder/blob/85eb2f1a644506946eb82a4b797a2d687d747d41/src/builder-module.c#L1745-L1751) shows that each command is run by a shell.