### PR TITLE
Don't prune build stages from cache with --{export,finish}-only

### DIFF
--- a/src/builder-cache.h
+++ b/src/builder-cache.h
@@ -59,6 +59,7 @@ GPtrArray   *builder_cache_get_changes (BuilderCache *self,
 GPtrArray   *builder_cache_get_all_changes (BuilderCache *self,
                                             GError      **error);
 gboolean      builder_gc (BuilderCache *self,
+                          gboolean      prune_unused_stages,
                           GError      **error);
 
 void builder_cache_checksum_str (BuilderCache *self,

--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -332,6 +332,7 @@ main (int    argc,
   gboolean is_run = FALSE;
   gboolean is_show_deps = FALSE;
   gboolean app_dir_is_empty = FALSE;
+  gboolean prune_unused_stages = FALSE;
   g_autoptr(FlatpakContext) arg_context = NULL;
   g_autoptr(FlatpakTempDir) cleanup_manifest_dir = NULL;
   g_autofree char *manifest_basename = NULL;
@@ -1064,7 +1065,10 @@ main (int    argc,
         }
     }
 
-  if (!builder_gc (cache, &error))
+  if (!opt_finish_only && !opt_export_only)
+    prune_unused_stages = TRUE;
+
+  if (!builder_gc (cache, prune_unused_stages, &error))
     {
       g_warning ("Failed to GC build cache: %s", error->message);
       g_clear_error (&error);


### PR DESCRIPTION
A commonly used CI workflow is to chain the following steps:

    > flatpak-builder --stop-at=<module>
    > flatpak build <commands to build module from local checkout>
    > flatpak-builder --finish-only

Unfortunately, the last step always purge all the compilation cache
created by the first one. All build steps are marked unused by default
and since they are skipped due to the option --finish-only, all of them
are always pruned by the gc function.

As a result, flatpak-builder cache becomes useless, a full compilation
is always performed.

Improve this by not cleaning unused stages when no compilation is done
by flatpak-builder (i.e: when flatpak-builder is used with --export-only
or --finish-only option).

See also: https://gitlab.gnome.org/GNOME/Initiatives/wikis/DevOps-with-Flatpak