### PR TITLE
Use GInputStream for checksum computation of source files & archives

### DIFF
--- a/src/builder-source-archive.c
+++ b/src/builder-source-archive.c
@@ -358,21 +358,10 @@ builder_source_archive_download (BuilderSource  *source,
 
   if (g_file_query_exists (file, NULL))
     {
-      if (is_local && checksums[0]  != NULL)
-        {
-          g_autofree char *data = NULL;
-          gsize len;
-
-          if (!g_file_load_contents (file, NULL, &data, &len, NULL, error))
-            return FALSE;
-
-          if (!builder_verify_checksums (base_name,
-                                         data, len,
-                                         checksums, checksums_type,
-                                         error))
-            return FALSE;
-        }
-      return TRUE;
+      return !is_local || checksums[0] == NULL ||
+             builder_verify_checksums (base_name, file,
+                                       checksums, checksums_type,
+                                       error);
     }
 
   if (is_local)

--- a/src/builder-source-file.c
+++ b/src/builder-source-file.c
@@ -347,21 +347,10 @@ builder_source_file_download (BuilderSource  *source,
 
   if (g_file_query_exists (file, NULL))
     {
-      if (is_local && checksums[0] != NULL)
-        {
-          g_autofree char *data = NULL;
-          gsize len;
-
-          if (!g_file_load_contents (file, NULL, &data, &len, NULL, error))
-            return FALSE;
-
-          if (!builder_verify_checksums (base_name,
-                                         data, len,
-                                         checksums, checksums_type,
-                                         error))
-            return FALSE;
-        }
-      return TRUE;
+      return !is_local || checksums[0] == NULL ||
+             builder_verify_checksums (base_name, file,
+                                       checksums, checksums_type,
+                                       error);
     }
 
   if (is_local)

--- a/src/builder-utils.h
+++ b/src/builder-utils.h
@@ -99,8 +99,7 @@ gsize builder_get_all_checksums (const char *checksums[BUILDER_CHECKSUMS_LEN],
                                  const char *sha512);
 
 gboolean builder_verify_checksums (const char *name,
-                                   const char *data,
-                                   gsize len,
+                                   GFile *file,
                                    const char *checksums[BUILDER_CHECKSUMS_LEN],
                                    GChecksumType checksums_type[BUILDER_CHECKSUMS_LEN],
                                    GError **error);


### PR DESCRIPTION
Using g_load_contents () for the checksum computation uses a lot of memory
(for large files) and actually fails for files larger than 4 GiB. Instead,
this implementation uses GInputStream to read the file in small buffers
and feeds the GChecksum manually.

Fixes #141.

I'm passing the GFile pointer in builder_verify_checksums () because I haven't found out how to clone a GObject or else I'd just pass GInputStream pointer.