### PR TITLE
install-deps: Always pass -y when installing

### DIFF
--- a/src/builder-manifest.c
+++ b/src/builder-manifest.c
@@ -3585,8 +3585,7 @@ builder_manifest_install_dep (BuilderManifest *self,
       g_ptr_array_add (args, g_strdup (remote));
     }
 
-  if (opt_yes)
-    g_ptr_array_add (args, "-y");
+  g_ptr_array_add (args, g_strdup ("-y"));
 
   g_ptr_array_add (args, g_strdup (ref));
   g_ptr_array_add (args, NULL);


### PR DESCRIPTION
The prompts don't currently work when we shell out to
flatpak, so this is broken without -y.