### PR TITLE
Fix --install with latest flatpak by passing -y

### DIFF
--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -277,8 +277,7 @@ do_install (BuilderContext *build_context,
   else
     g_ptr_array_add (args, g_strdup ("--system"));
 
-  if (opt_user)
-    g_ptr_array_add (args, g_strdup ("-y"));
+  g_ptr_array_add (args, g_strdup ("-y"));
 
   g_ptr_array_add (args, g_strdup ("--reinstall"));
 


### PR DESCRIPTION
These days flatpak install will always prompt for input,
so we pass -y to it because otherwise (due to non-inherited
stdin) we auto-answer no.

Fixes https://github.com/flatpak/flatpak-builder/issues/170