### PR TITLE
builder: Initialise git tree when using "use-git" for patches

### DIFF
--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -612,6 +612,10 @@
                         <listitem><para>A list of alternative urls that are used if the main url fails.</para></listitem>
                     </varlistentry>
                     <varlistentry>
+                        <term><option>git-init</option> (boolean)</term>
+                        <listitem><para>Whether to initialise the repository as a git repository.</para></listitem>
+                    </varlistentry>
+                    <varlistentry>
                         <term><option>md5</option> (string)</term>
                         <listitem><para>The md5 checksum of the file, verified after download</para>
                         <para>Note that md5 is no longer considered a safe checksum, we recommend you use at least sha256.</para>

--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -835,6 +835,10 @@
                         <listitem><para>Whether to use "git apply" rather than "patch" to apply the patch, required when the patch file contains binary diffs.</para></listitem>
                     </varlistentry>
                     <varlistentry>
+                        <term><option>use-git-am</option> (boolean)</term>
+                        <listitem><para>Whether to use "git am" rather than "patch" to apply the patch, required when the patch file contains binary diffs. You cannot use this at the same time as <option>use-git</option>.</para></listitem>
+                    </varlistentry>
+                    <varlistentry>
                         <term><option>options</option> (array of strings)</term>
                         <listitem><para>Extra options to pass to the patch command.</para></listitem>
                     </varlistentry>


### PR DESCRIPTION
When applying patches using git, git apply will ignore non-existent
patches that apply to non-existent files. As the vanilla source we use
to apply those patches might not be a git tree (eg. a tarball), make
sure that the tree is initialised before apply those git patches.

Fixes "Skipped patch ..." messages appearing in builds.