### PR TITLE
Support alternative builds

### DIFF
--- a/doc/flatpak-builder.xml
+++ b/doc/flatpak-builder.xml
@@ -349,6 +349,16 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--alt=ALTNAME</option></term>
+
+                <listitem><para>
+                  Build an alternative version of the manifest specified by the name and the alt options
+                  (like e.g. only-alts) in the manifest. If this is not specified the alternative used is
+                  called "default".
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--stop-at=MODULENAME</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -379,6 +379,10 @@
                     <term><option>arch</option> (object)</term>
                     <listitem><para>This is a dictionary defining for each arch a separate build options object that override the main one.</para></listitem>
                 </varlistentry>
+                <varlistentry>
+                    <term><option>alt</option> (object)</term>
+                    <listitem><para>This is a dictionary defining for each named alternate build a separate options object that override the main one. This object may also have per-arch sub-options.</para></listitem>
+                </varlistentry>
             </variablelist>
         </refsect2>
         <refsect2>
@@ -540,6 +544,14 @@
                     <listitem><para>Don't build on any of the arches listed.</para></listitem>
                 </varlistentry>
                 <varlistentry>
+                    <term><option>only-alts</option> (array of strings)</term>
+                    <listitem><para>If non-empty, only build the module on the alternative builds listed.</para></listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term><option>skip-alts</option> (array of strings)</term>
+                    <listitem><para>Don't build in any of the alternative builds listed.</para></listitem>
+                </varlistentry>
+                <varlistentry>
                     <term><option>cleanup-platform</option> (array of strings)</term>
                     <listitem><para>Extra files to clean up in the platform.</para></listitem>
                 </varlistentry>
@@ -578,11 +590,19 @@
                 <variablelist>
                   <varlistentry>
                     <term><option>only-arches</option> (array of strings)</term>
-                    <listitem><para>If non-empty, only build the module on the arches listed.</para></listitem>
+                    <listitem><para>If non-empty, only include the source on the arches listed.</para></listitem>
                   </varlistentry>
                   <varlistentry>
                     <term><option>skip-arches</option> (array of strings)</term>
-                    <listitem><para>Don't build on any of the arches listed.</para></listitem>
+                    <listitem><para>Don't include the source on any of the arches listed.</para></listitem>
+                  </varlistentry>
+                  <varlistentry>
+                    <term><option>only-alts</option> (array of strings)</term>
+                    <listitem><para>If non-empty, only include the source on the alternative builds listed.</para></listitem>
+                  </varlistentry>
+                  <varlistentry>
+                    <term><option>skip-alts</option> (array of strings)</term>
+                    <listitem><para>Don't include the source on any of the alternative builds listed.</para></listitem>
                   </varlistentry>
                     <varlistentry>
                         <term><option>dest</option> (string)</term>

--- a/src/builder-context.c
+++ b/src/builder-context.c
@@ -48,6 +48,7 @@ struct BuilderContext
   SoupSession    *soup_session;
   CURL           *curl_session;
   char           *arch;
+  char           *alt;
   char           *stop_at;
 
   GFile          *download_dir;
@@ -118,6 +119,7 @@ builder_context_finalize (GObject *object)
   g_clear_object (&self->options);
   g_clear_object (&self->sdk_config);
   g_free (self->arch);
+  g_free (self->alt);
   g_free (self->state_subdir);
   g_free (self->stop_at);
   g_strfreev (self->cleanup);
@@ -561,6 +563,32 @@ builder_context_set_arch (BuilderContext *self,
 {
   g_free (self->arch);
   self->arch = g_strdup (arch);
+}
+
+const char *
+builder_context_get_alt (BuilderContext *self)
+{
+  return (const char *) self->alt;
+}
+
+const char *
+builder_context_get_defaulted_alt (BuilderContext *self)
+{
+  if (self->alt == NULL)
+    return "default";
+  return (const char *) self->alt;
+}
+
+void
+builder_context_set_alt (BuilderContext *self,
+                         const char     *alt)
+{
+  g_free (self->alt);
+
+  if (g_strcmp0 (alt, "default") == 0)
+    alt = NULL;
+
+  self->alt = g_strdup (alt);
 }
 
 const char *

--- a/src/builder-context.h
+++ b/src/builder-context.h
@@ -74,6 +74,10 @@ CURL *          builder_context_get_curl_session (BuilderContext *self);
 const char *    builder_context_get_arch (BuilderContext *self);
 void            builder_context_set_arch (BuilderContext *self,
                                           const char     *arch);
+const char *    builder_context_get_alt  (BuilderContext *self);
+const char *    builder_context_get_defaulted_alt (BuilderContext *self);
+void            builder_context_set_alt  (BuilderContext *self,
+                                          const char *alt);
 const char *    builder_context_get_stop_at (BuilderContext *self);
 void            builder_context_set_stop_at (BuilderContext *self,
                                              const char     *module);

--- a/src/builder-manifest.c
+++ b/src/builder-manifest.c
@@ -1704,7 +1704,6 @@ builder_manifest_checksum (BuilderManifest *self,
   builder_cache_checksum_str (cache, self->base_commit);
   builder_cache_checksum_strv (cache, self->base_extensions);
   builder_cache_checksum_compat_str (cache, self->extension_tag);
-
   if (self->build_options)
     builder_options_checksum (self->build_options, cache, context);
 

--- a/src/builder-module.c
+++ b/src/builder-module.c
@@ -54,6 +54,8 @@ struct BuilderModule
   char          **ensure_writable;
   char          **only_arches;
   char          **skip_arches;
+  char          **only_alts;
+  char          **skip_alts;
   gboolean        disabled;
   gboolean        rm_configure;
   gboolean        no_autogen;
@@ -103,8 +105,10 @@ enum {
   PROP_MAKE_INSTALL_ARGS,
   PROP_ENSURE_WRITABLE,
   PROP_ONLY_ARCHES,
-  PROP_RUN_TESTS,
   PROP_SKIP_ARCHES,
+  PROP_ONLY_ALTS,
+  PROP_SKIP_ALTS,
+  PROP_RUN_TESTS,
   PROP_SOURCES,
   PROP_BUILD_OPTIONS,
   PROP_CLEANUP,
@@ -149,6 +153,8 @@ builder_module_finalize (GObject *object)
   g_strfreev (self->ensure_writable);
   g_strfreev (self->only_arches);
   g_strfreev (self->skip_arches);
+  g_strfreev (self->only_alts);
+  g_strfreev (self->skip_alts);
   g_clear_object (&self->build_options);
   g_list_free_full (self->sources, g_object_unref);
   g_strfreev (self->cleanup);
@@ -247,6 +253,14 @@ builder_module_get_property (GObject    *object,
 
     case PROP_SKIP_ARCHES:
       g_value_set_boxed (value, self->skip_arches);
+      break;
+
+    case PROP_ONLY_ALTS:
+      g_value_set_boxed (value, self->only_alts);
+      break;
+
+    case PROP_SKIP_ALTS:
+      g_value_set_boxed (value, self->skip_alts);
       break;
 
     case PROP_POST_INSTALL:
@@ -395,6 +409,18 @@ builder_module_set_property (GObject      *object,
     case PROP_SKIP_ARCHES:
       tmp = self->skip_arches;
       self->skip_arches = g_strdupv (g_value_get_boxed (value));
+      g_strfreev (tmp);
+      break;
+
+    case PROP_ONLY_ALTS:
+      tmp = self->only_alts;
+      self->only_alts = g_strdupv (g_value_get_boxed (value));
+      g_strfreev (tmp);
+      break;
+
+    case PROP_SKIP_ALTS:
+      tmp = self->skip_alts;
+      self->skip_alts = g_strdupv (g_value_get_boxed (value));
       g_strfreev (tmp);
       break;
 
@@ -597,6 +623,20 @@ builder_module_class_init (BuilderModuleClass *klass)
   g_object_class_install_property (object_class,
                                    PROP_SKIP_ARCHES,
                                    g_param_spec_boxed ("skip-arches",
+                                                       "",
+                                                       "",
+                                                       G_TYPE_STRV,
+                                                       G_PARAM_READWRITE));
+  g_object_class_install_property (object_class,
+                                   PROP_ONLY_ALTS,
+                                   g_param_spec_boxed ("only-alts",
+                                                       "",
+                                                       "",
+                                                       G_TYPE_STRV,
+                                                       G_PARAM_READWRITE));
+  g_object_class_install_property (object_class,
+                                   PROP_SKIP_ALTS,
+                                   g_param_spec_boxed ("skip-alts",
                                                        "",
                                                        "",
                                                        G_TYPE_STRV,
@@ -945,6 +985,15 @@ builder_module_is_enabled (BuilderModule *self,
 
   if (self->skip_arches != NULL &&
       g_strv_contains ((const char * const *)self->skip_arches, builder_context_get_arch (context)))
+    return FALSE;
+
+  if (self->only_alts != NULL &&
+      self->only_alts[0] != NULL &&
+      !g_strv_contains ((const char * const *) self->only_alts, builder_context_get_defaulted_alt (context)))
+    return FALSE;
+
+  if (self->skip_alts != NULL &&
+      g_strv_contains ((const char * const *)self->skip_alts, builder_context_get_defaulted_alt (context)))
     return FALSE;
 
   return TRUE;
@@ -1961,6 +2010,8 @@ builder_module_checksum (BuilderModule  *self,
   builder_cache_checksum_strv (cache, self->ensure_writable);
   builder_cache_checksum_strv (cache, self->only_arches);
   builder_cache_checksum_strv (cache, self->skip_arches);
+  builder_cache_checksum_compat_strv (cache, self->only_alts);
+  builder_cache_checksum_compat_strv (cache, self->skip_alts);
   builder_cache_checksum_boolean (cache, self->rm_configure);
   builder_cache_checksum_boolean (cache, self->no_autogen);
   builder_cache_checksum_boolean (cache, self->disabled);

--- a/src/builder-source.h
+++ b/src/builder-source.h
@@ -45,6 +45,8 @@ struct BuilderSource
   char   *dest;
   char  **only_arches;
   char  **skip_arches;
+  char  **only_alts;
+  char  **skip_alts;
 };
 
 typedef struct


### PR DESCRIPTION
This allows you to specify alternative builds in one manifest file.
You specify the alternative on the commandline like:
  flatpak-builder --alt=NAME ...

And this then builds the manifest like normally, but with a different
cache base-name (so that both alternatives can be cached at the
same time). However, using the new "alt" option in BuildOption
and [only|skip]-alts options in modules and sources you can
affect what gets built and how. This is very similar to how
things can already be per-arch optional.