### PR TITLE
module: Respect "no-parallel-make" with ninja

### DIFF
--- a/src/builder-module.c
+++ b/src/builder-module.c
@@ -1706,6 +1706,11 @@ builder_module_build_helper (BuilderModule  *self,
       make_j = g_strdup_printf ("-j%d", builder_context_get_jobs (context));
       make_l = g_strdup_printf ("-l%d", 2 * builder_context_get_jobs (context));
     }
+  else if (meson || cmake_ninja)
+    {
+      /* ninja defaults to a parallel make, disable it if requested */
+      make_j = g_strdup ("-j1");
+    }
 
   if (run_shell)
     {


### PR DESCRIPTION
ninja defaults to running in a highly parallel mode, but some bugs in
meson, such as:
https://github.com/mesonbuild/meson/issues/1994
require building serially.

This change makes the cmake-ninja and meson buildsystems respect
"no-parallel-make" during building.