### PR TITLE
doc: Replace git.gnome.org with gitlab.gnome.org

### DIFF
--- a/doc/flatpak-builder.xml
+++ b/doc/flatpak-builder.xml
@@ -664,7 +664,7 @@
             "sources": [
                 {
                     "type": "git",
-                    "url": "git://git.gnome.org/babl"
+                    "url": "https://gitlab.gnome.org/GNOME/babl.git"
                 }
             ]
         },

--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -1036,7 +1036,7 @@
             "sources": [
                 {
                     "type": "git",
-                    "url": "git://git.gnome.org/babl"
+                    "url": "https://gitlab.gnome.org/GNOME/babl.git"
                 }
             ]
         },


### PR DESCRIPTION
GNOME has migrated to gitlab.