### PR TITLE
Flatpak builder --run recursive

### DIFF
--- a/src/builder-manifest.c
+++ b/src/builder-manifest.c
@@ -3831,10 +3831,21 @@ builder_manifest_run (BuilderManifest *self,
   commandline = flatpak_quote_argv ((const char **) args->pdata);
   g_debug ("Running '%s'", commandline);
 
-  if (execvp ((char *) args->pdata[0], (char **) args->pdata) == -1)
+
+  if (flatpak_is_in_sandbox ())
     {
-      g_set_error (error, G_IO_ERROR, g_io_error_from_errno (errno), "Unable to start flatpak build");
-      return FALSE;
+      if (builder_host_spawnv (NULL, NULL, G_SUBPROCESS_FLAGS_STDIN_INHERIT, NULL, (const gchar * const  *)args->pdata))
+        exit (1);
+      else
+        exit (0);
+    }
+  else
+    {
+      if (execvp ((char *) args->pdata[0], (char **) args->pdata) == -1)
+        {
+          g_set_error (error, G_IO_ERROR, g_io_error_from_errno (errno), "Unable to start flatpak build");
+          return FALSE;
+        }
     }
 
   /* Not reached */

--- a/src/builder-utils.c
+++ b/src/builder-utils.c
@@ -1618,10 +1618,18 @@ builder_host_spawnv (GFile                *dir,
   guint sigterm_id = 0, sigint_id = 0;
   g_autofree gchar *commandline = NULL;
   g_autoptr(GOutputStream) out = NULL;
+  g_autoptr(GFile) cwd = NULL;
   glnx_fd_close int blocking_stdin_fd = -1;
   int pipefd[2];
   int stdin_fd;
   int i;
+
+  if (dir == NULL)
+    {
+      g_autofree char *current_dir = g_get_current_dir ();
+      cwd = g_file_new_for_path (current_dir);
+      dir = cwd;
+    }
 
   commandline = flatpak_quote_argv ((const char **) argv);
   g_debug ("Running '%s' on host", commandline);

--- a/src/builder-utils.c
+++ b/src/builder-utils.c
@@ -1574,7 +1574,7 @@ sigterm_handler (gpointer user_data)
                                G_DBUS_CALL_FLAGS_NONE, -1,
                                NULL, NULL);
 
-  kill (getpid (), SIGTERM);
+  kill (getpid (), SIGKILL);
   return TRUE;
 }
 
@@ -1593,7 +1593,7 @@ sigint_handler (gpointer user_data)
                                G_DBUS_CALL_FLAGS_NONE, -1,
                                NULL, NULL);
 
-  kill (getpid (), SIGTERM);
+  kill (getpid (), SIGKILL);
   return TRUE;
 }
 

--- a/src/builder-utils.c
+++ b/src/builder-utils.c
@@ -1781,7 +1781,7 @@ builder_maybe_host_spawnv (GFile                *dir,
                            const gchar * const  *argv)
 {
   if (flatpak_is_in_sandbox ())
-    return builder_host_spawnv (dir, output, 0, error, argv);
+    return builder_host_spawnv (dir, output, flags, error, argv);
 
   return flatpak_spawnv (dir, output, flags, error, argv);
 }


### PR DESCRIPTION
Various fixes to make flatpak-builder --run work when in a sandbox. 
This fixes https://github.com/flatpak/flatpak-builder/issues/188, although there is still an issue with flatpak-builder --run not really doing ctrl-c correctly in the sandboxed case.