### PR TITLE
patch source: Add paths option to specify multiple patches

### DIFF
--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -830,6 +830,10 @@
                         <listitem><para>The path of a patch file that will be applied in the source dir</para></listitem>
                     </varlistentry>
                     <varlistentry>
+                        <term><option>paths</option> (array of strings)</term>
+                        <listitem><para>An list of paths to a patch files that will be applied in the source dir, in order</para></listitem>
+                    </varlistentry>
+                    <varlistentry>
                         <term><option>strip-components</option> (integer)</term>
                         <listitem><para>The value of the -p argument to patch, defaults to 1.</para></listitem>
                     </varlistentry>


### PR DESCRIPTION
In many cases you have a list of patches to apply, with the same
args. This allows you to do that by just listing the patches in
order, thus making the manifest more compact.