### PR TITLE
Run screenshot mirroring in sandbox

### DIFF
--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -912,6 +912,11 @@ main (int    argc,
 
       if (g_file_query_exists (xml, NULL))
         {
+          if (!flatpak_break_hardlink (xml, &error))
+            {
+              g_printerr ("Error mirroring screenshots: %s\n", error->message);
+              return 1;
+            }
           if (!builder_maybe_host_spawnv (NULL,
                                           NULL,
                                           0,


### PR DESCRIPTION
The old version of appstream-glib on the flathub builders are causing problems, and we already rely on appstream-glib in the runtime for appstream-compose, so we might as well run the screenshot mirroring in the sandbox too.

Also, this fixes an issue where the rewrite of the xml file causes issues with the f-b cache repo.