### PR TITLE
script: Disable reading of profile data for script sources

### DIFF
--- a/src/builder-source-script.c
+++ b/src/builder-source-script.c
@@ -138,7 +138,8 @@ builder_source_script_extract (BuilderSource  *source,
   int i;
   guint32 perms;
 
-  script = g_string_new ("#!/bin/sh\n");
+  /* --norc is already on when bash is invoked as sh */
+  script = g_string_new ("#!/bin/sh --noprofile\n");
 
   if (self->commands)
     {


### PR DESCRIPTION
This avoids applications with home or host filesystem access importing
the user's profile or the system-wide one. The rc files are already
ignored as we launch /bin/sh which enables --norc itself.