### PR TITLE
Mention the correct usage of git via SSH

### DIFF
--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -661,7 +661,7 @@
                     </varlistentry>
                     <varlistentry>
                         <term><option>url</option> (string)</term>
-                        <listitem><para>URL of the git repository. This overrides path if both are specified.</para></listitem>
+                        <listitem><para>URL of the git repository. This overrides path if both are specified. When using git via SSH, the correct syntax is ssh://user@domain/path/to/repo.git.</para></listitem>
                     </varlistentry>
                     <varlistentry>
                         <term><option>branch</option> (string)</term>


### PR DESCRIPTION
As it turned out, one needs to add the prefix `ssh://` when using git repos via ssh. I.e. 

<pre>
                {
                    "type": "git",
                    "url": "git@git.myprivategit.local:master/dependency.git",
                    "branch": "master"
                }
</pre>

doesn't work, however

<pre>
                {
                    "type": "git",
                    "url": "ssh://git@git.myprivategit.local/master/dependency.git",
                    "branch": "master"
                }
</pre>

works fine. This wasn't obvious to me, as you don't need the prefix for `git` itself. Others might have the same problem.