### PR TITLE
Set SOURCE_DATE_EPOCH to the mtime of the manifest

### DIFF
--- a/src/builder-context.c
+++ b/src/builder-context.c
@@ -49,6 +49,7 @@ struct BuilderContext
   CURL           *curl_session;
   char           *arch;
   char           *stop_at;
+  gint64          source_date_epoch;
 
   GFile          *download_dir;
   GPtrArray      *sources_dirs;
@@ -565,6 +566,13 @@ builder_context_set_arch (BuilderContext *self,
   self->arch = g_strdup (arch);
 }
 
+void
+builder_context_set_source_date_epoch (BuilderContext *self,
+                                       gint64 source_date_epoch)
+{
+  self->source_date_epoch = source_date_epoch;
+}
+
 const char *
 builder_context_get_stop_at (BuilderContext *self)
 {
@@ -1029,6 +1037,12 @@ builder_context_extend_env (BuilderContext *self,
 
   envp = g_environ_setenv (envp, "CCACHE_DIR", ccache_dir, TRUE);
   envp = g_environ_setenv (envp, "PATH", path, TRUE);
+
+  if (self->source_date_epoch != 0)
+    {
+      g_autofree char *s_d_e = g_strdup_printf ("%" G_GUINT64_FORMAT, self->source_date_epoch);
+      envp = g_environ_setenv (envp, "SOURCE_DATE_EPOCH", s_d_e, FALSE);
+    }
 
   return envp;
 }

--- a/src/builder-context.h
+++ b/src/builder-context.h
@@ -74,6 +74,8 @@ CURL *          builder_context_get_curl_session (BuilderContext *self);
 const char *    builder_context_get_arch (BuilderContext *self);
 void            builder_context_set_arch (BuilderContext *self,
                                           const char     *arch);
+void            builder_context_set_source_date_epoch (BuilderContext *self,
+                                                       gint64 source_date_epoch);
 const char *    builder_context_get_stop_at (BuilderContext *self);
 void            builder_context_set_stop_at (BuilderContext *self,
                                              const char     *module);

--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -442,6 +442,7 @@ main (int    argc,
   int i, first_non_arg, orig_argc;
   int argnr;
   char *p;
+  struct stat statbuf;
 
   setlocale (LC_ALL, "");
 
@@ -658,6 +659,9 @@ main (int    argc,
       g_printerr ("Can't load '%s': %s\n", manifest_rel_path, error->message);
       return 1;
     }
+
+  if (stat (flatpak_file_get_path_cached (manifest_file), &statbuf) == 0)
+    builder_context_set_source_date_epoch (build_context, (gint64)statbuf.st_mtime);
 
   manifest_sha256 = g_compute_checksum_for_string (G_CHECKSUM_SHA256, manifest_contents, -1);
 


### PR DESCRIPTION
This will help make reproducible builds.

As mentioned in https://github.com/flatpak/flatpak-builder/issues/247#issuecomment-450585337