### PR TITLE
Allow unsetting SOURCE_DATE_EPOCH and other env vars

### DIFF
--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -340,7 +340,7 @@
                 </varlistentry>
                 <varlistentry>
                     <term><option>env</option> (object)</term>
-                    <listitem><para>This is a dictionary defining environment variables to be set during the build. Elements in this override the properties that set the environment, like cflags and ldflags.</para></listitem>
+                    <listitem><para>This is a dictionary defining environment variables to be set during the build. Elements in this override the properties that set the environment, like cflags and ldflags. Keys with a null value unset the corresponding variable. </para></listitem>
                 </varlistentry>
                 <varlistentry>
                     <term><option>build-args</option> (array of strings)</term>

--- a/src/builder-context.c
+++ b/src/builder-context.c
@@ -1013,8 +1013,21 @@ builder_context_set_enable_ccache (BuilderContext *self,
 }
 
 char **
-builder_context_extend_env (BuilderContext *self,
-                            char          **envp)
+builder_context_extend_env_pre (BuilderContext *self,
+                                char          **envp)
+{
+  if (self->source_date_epoch != 0)
+    {
+      g_autofree char *s_d_e = g_strdup_printf ("%" G_GUINT64_FORMAT, self->source_date_epoch);
+      envp = g_environ_setenv (envp, "SOURCE_DATE_EPOCH", s_d_e, FALSE);
+    }
+
+  return envp;
+}
+
+char **
+builder_context_extend_env_post (BuilderContext *self,
+                                 char          **envp)
 {
   g_autofree char *path = NULL;
   const char *ccache_dir = NULL;
@@ -1037,12 +1050,6 @@ builder_context_extend_env (BuilderContext *self,
 
   envp = g_environ_setenv (envp, "CCACHE_DIR", ccache_dir, TRUE);
   envp = g_environ_setenv (envp, "PATH", path, TRUE);
-
-  if (self->source_date_epoch != 0)
-    {
-      g_autofree char *s_d_e = g_strdup_printf ("%" G_GUINT64_FORMAT, self->source_date_epoch);
-      envp = g_environ_setenv (envp, "SOURCE_DATE_EPOCH", s_d_e, FALSE);
-    }
 
   return envp;
 }

--- a/src/builder-context.h
+++ b/src/builder-context.h
@@ -142,8 +142,10 @@ void            builder_context_set_run_tests (BuilderContext *self,
 void            builder_context_set_no_shallow_clone (BuilderContext *self,
                                                       gboolean        no_shallow_clone);
 gboolean        builder_context_get_no_shallow_clone (BuilderContext *self);
-char **         builder_context_extend_env (BuilderContext *self,
-                                            char          **envp);
+char **         builder_context_extend_env_pre (BuilderContext *self,
+                                                 char          **envp);
+char **         builder_context_extend_env_post (BuilderContext *self,
+                                                 char          **envp);
 
 gboolean        builder_context_load_sdk_config (BuilderContext       *self,
                                                  const char           *sdk_path,

--- a/src/builder-options.c
+++ b/src/builder-options.c
@@ -1093,6 +1093,8 @@ builder_options_get_env (BuilderOptions *self, BuilderContext *context)
   char **envp = NULL;
   const char *cflags, *cppflags, *cxxflags, *ldflags;
 
+  envp = builder_context_extend_env_pre (context, envp);
+
   cflags = builder_options_get_cflags (self, context);
   if (cflags)
     envp = g_environ_setenv (envp, "CFLAGS", cflags, FALSE);
@@ -1137,7 +1139,7 @@ builder_options_get_env (BuilderOptions *self, BuilderContext *context)
         }
     }
 
-  envp = builder_context_extend_env (context, envp);
+  envp = builder_context_extend_env_post (context, envp);
 
   envp = builder_options_update_path (self, context, envp);
   envp = builder_options_update_ld_path (self, context, envp);

--- a/src/builder-utils.c
+++ b/src/builder-utils.c
@@ -408,6 +408,11 @@ parse_yaml_node_to_json (yaml_document_t *doc, yaml_node_t *node)
               json_node_init_boolean (json, FALSE);
               break;
             }
+          else if (strcmp (scalar, "null") == 0)
+            {
+              json_node_init_null (json);
+              break;
+            }
 
           if (*scalar != '\0')
             {


### PR DESCRIPTION
As per https://github.com/flatpak/flatpak-builder/issues/247#issuecomment-453937152, the new SOURCE_DATE_EPOCH support can cause problems for some apps, and we need to be able to disable it.

With this change, QuodLibet build with this change:

```
diff --git a/io.github.quodlibet.QuodLibet.yaml b/io.github.quodlibet.QuodLibet.yaml
index 3252741..147fef6 100644
--- a/io.github.quodlibet.QuodLibet.yaml
+++ b/io.github.quodlibet.QuodLibet.yaml
@@ -118,6 +118,9 @@ modules:
         url: https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-1.14.4.tar.xz
         sha256: 910b4e0e2e897e8b6d06767af1779d70057c309f67292f485ff988d087aa0de5
   - name: quodlibet
+    build-options:
+      env:
+        SOURCE_DATE_EPOCH: null
     buildsystem: simple
     subdir: quodlibet
     build-commands:
```