### PR TITLE
docs: Clarify that command: is only for flatpak run

### DIFF
--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -106,7 +106,16 @@
                 </varlistentry>
                 <varlistentry>
                     <term><option>command</option> (string)</term>
-                    <listitem><para>The filename or path to the main binary of the application. Note that this is really just a single file, not a commandline. If you want to pass arguments, install a shell script wrapper and use that as the command.</para></listitem>
+                    <listitem><para>
+                        The filename or path to the main binary of the application. Note that this
+                        is really just a single file, not a commandline. If you want to pass arguments,
+                        install a shell script wrapper and use that as the command.
+                    </para><para>
+                        Also note that the command is used when the application is run via
+                        <command>flatpak run</command>, and does not affect what gets executed when
+                        the application is run in other ways, e.g. via the desktop file or D-Bus
+                        activation.
+                    </para></listitem>
                 </varlistentry>
                 <varlistentry>
                     <term><option>build-runtime</option> (boolean)</term>


### PR DESCRIPTION
This may not otherwise be obvious.