### PR TITLE
Handle submodules in the --from-git case

### DIFF
--- a/src/builder-git.c
+++ b/src/builder-git.c
@@ -822,44 +822,6 @@ git_extract_submodule (const char     *repo_location,
 }
 
 gboolean
-builder_git_checkout_dir (const char     *repo_location,
-                          const char     *branch,
-                          const char     *dir,
-                          GFile          *dest,
-                          BuilderContext *context,
-                          GError        **error)
-{
-  g_autoptr(GFile) mirror_dir = NULL;
-  g_autofree char *mirror_dir_path = NULL;
-  g_autofree char *dest_path = NULL;
-  g_autofree char *dest_path_git = NULL;
-
-  mirror_dir = git_get_mirror_dir (repo_location, context);
-
-  mirror_dir_path = g_file_get_path (mirror_dir);
-  dest_path = g_file_get_path (dest);
-  dest_path_git = g_build_filename (dest_path, ".git", NULL);
-
-  g_mkdir_with_parents (dest_path, 0755);
-
-  if (!cp (error,
-           "-al",
-           mirror_dir_path, dest_path_git, NULL))
-    return FALSE;
-
-  /* Then we need to convert to regular */
-  if (!git (dest, NULL, 0, error,
-            "config", "--bool", "core.bare", "false", NULL))
-    return FALSE;
-
-  if (!git (dest, NULL, 0, error,
-            "checkout", branch, "--", dir ? dir : ".", NULL))
-    return FALSE;
-
-  return TRUE;
-}
-
-gboolean
 builder_git_checkout (const char     *repo_location,
                       const char     *branch,
                       GFile          *dest,

--- a/src/builder-git.h
+++ b/src/builder-git.h
@@ -49,12 +49,6 @@ gboolean builder_git_checkout           (const char      *repo_location,
                                          GFile           *dest,
                                          BuilderContext  *context,
                                          GError         **error);
-gboolean builder_git_checkout_dir       (const char      *repo_location,
-                                         const char      *branch,
-                                         const char      *dir,
-                                         GFile           *dest,
-                                         BuilderContext  *context,
-                                         GError         **error);
 gboolean builder_git_shallow_mirror_ref (const char     *repo_location,
                                          const char     *destination_path,
                                          const char     *ref,

--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -639,12 +639,11 @@ main (int    argc,
           return 1;
         }
 
-      if (!builder_git_checkout_dir (opt_from_git,
-                                     git_branch,
-                                     manifest_dirname,
-                                     build_subdir,
-                                     build_context,
-                                     &error))
+      if (!builder_git_checkout (opt_from_git,
+                                 git_branch,
+                                 build_subdir,
+                                 build_context,
+                                 &error))
         {
           g_printerr ("Can't check out manifest repo: %s\n", error->message);
           return 1;

--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -623,9 +623,16 @@ main (int    argc,
 
       cleanup_manifest_dir = g_object_ref (build_subdir);
 
+      int mirror_flags = FLATPAK_GIT_MIRROR_FLAGS_MIRROR_SUBMODULES;
+
+      if (opt_disable_updates)
+        {
+          mirror_flags |= FLATPAK_GIT_MIRROR_FLAGS_UPDATE;
+	}
+
       if (!builder_git_mirror_repo (opt_from_git,
                                     NULL,
-                                    opt_disable_updates?0:FLATPAK_GIT_MIRROR_FLAGS_UPDATE,
+                                    mirror_flags,
                                     git_branch, build_context, &error))
         {
           g_printerr ("Can't clone manifest repo: %s\n", error->message);


### PR DESCRIPTION
Totem nightly is now failing:

http://sdkbuilder.gnome.org/logs/build-2019-01-18-141001/build-gnome-apps-nightly-master-org.gnome.Totem-x86_64.txt

That's because the Totem manifest now makes use of Flathub's shared-modules repo as a Git submodule. Other manifests might start doing something similar of course.

This branch teaches flatpak-builder to work with that.