### PR TITLE
Compress the changes stored in the flatpak-builder cache

### DIFF
--- a/src/builder-utils.h
+++ b/src/builder-utils.h
@@ -170,6 +170,13 @@ FlatpakXml *flatpak_xml_find (FlatpakXml  *node,
                               const char  *type,
                               FlatpakXml **prev_child_out);
 
+GBytes *   flatpak_read_stream (GInputStream *in,
+                                gboolean      null_terminate,
+                                GError      **error);
+GVariant * flatpak_variant_compress (GVariant *variant);
+GVariant * flatpak_variant_uncompress (GVariant *variant, const GVariantType *type);
+
+
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FlatpakXml, flatpak_xml_free);
 
 G_END_DECLS


### PR DESCRIPTION
These contain all the filenames that changed in a single module, and they are stored in the metadata for ostree commit object. @stbergmann ran into size issues in the libreoffice build where ostree limits these to 10Mb.

These are pathname strings so should compress well, so we just gzip the string lists.