### PR TITLE
manifest: Add default-branch key

### DIFF
--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -58,7 +58,24 @@
                 </varlistentry>
                 <varlistentry>
                     <term><option>branch</option> (string)</term>
-                    <listitem><para>The branch of the application, defaults to master.</para></listitem>
+                    <listitem><para>The branch to use when exporting
+                    the application. If this is unset the defaults
+                    come from the default-branch option.</para>
+                    <para>This key overrides both the default-branch
+                    key, and the --default-branch commandline
+                    option. Unless you need a very specific branchname
+                    (like for a runtime or an extension) it is
+                    recommended to use the default-branch key instead, because
+                    you can then override the default using --default-branch when
+                    building for instance a test build.</para></listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term><option>default-branch</option> (string)</term>
+                    <listitem><para>The default branch to use when
+                    exporting the application. Defaults to master. </para>
+                    <para>This key can be overriden by the
+                    --default-branch commandline
+                    option.</para></listitem>
                 </varlistentry>
                 <varlistentry>
                     <term><option>collection-id</option> (string)</term>

--- a/src/builder-context.c
+++ b/src/builder-context.c
@@ -48,6 +48,7 @@ struct BuilderContext
   SoupSession    *soup_session;
   CURL           *curl_session;
   char           *arch;
+  char           *default_branch;
   char           *stop_at;
   gint64          source_date_epoch;
 
@@ -119,6 +120,7 @@ builder_context_finalize (GObject *object)
   g_clear_object (&self->options);
   g_clear_object (&self->sdk_config);
   g_free (self->arch);
+  g_free (self->default_branch);
   g_free (self->state_subdir);
   g_free (self->stop_at);
   g_strfreev (self->cleanup);
@@ -564,6 +566,20 @@ builder_context_set_arch (BuilderContext *self,
 {
   g_free (self->arch);
   self->arch = g_strdup (arch);
+}
+
+const char *
+builder_context_get_default_branch (BuilderContext *self)
+{
+  return (const char *) self->default_branch;
+}
+
+void
+builder_context_set_default_branch (BuilderContext *self,
+                                    const char     *default_branch)
+{
+  g_free (self->default_branch);
+  self->default_branch = g_strdup (default_branch);
 }
 
 void

--- a/src/builder-context.h
+++ b/src/builder-context.h
@@ -74,6 +74,9 @@ CURL *          builder_context_get_curl_session (BuilderContext *self);
 const char *    builder_context_get_arch (BuilderContext *self);
 void            builder_context_set_arch (BuilderContext *self,
                                           const char     *arch);
+const char *    builder_context_get_default_branch (BuilderContext *self);
+void            builder_context_set_default_branch (BuilderContext *self,
+                                                    const char     *default_branch);
 void            builder_context_set_source_date_epoch (BuilderContext *self,
                                                        gint64 source_date_epoch);
 const char *    builder_context_get_stop_at (BuilderContext *self);

--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -690,7 +690,7 @@ main (int    argc,
     }
 
   if (opt_default_branch)
-    builder_manifest_set_default_branch (manifest, opt_default_branch);
+    builder_context_set_default_branch (build_context, opt_default_branch);
 
   if (opt_collection_id)
     builder_manifest_set_default_collection_id (manifest, opt_collection_id);
@@ -928,7 +928,7 @@ main (int    argc,
   if (opt_mirror_screenshots_url && !opt_export_only)
     {
       g_autofree char *screenshot_subdir = g_strdup_printf ("%s-%s", builder_manifest_get_id (manifest),
-                                                            builder_manifest_get_branch (manifest));
+                                                            builder_manifest_get_branch (manifest, build_context));
       g_autofree char *url = g_build_filename (opt_mirror_screenshots_url, screenshot_subdir, NULL);
       g_autofree char *xml_relpath = g_strdup_printf ("files/share/app-info/xmls/%s.xml.gz", builder_manifest_get_id (manifest));
       g_autoptr(GFile) xml = g_file_resolve_relative_path (app_dir, xml_relpath);
@@ -1010,7 +1010,7 @@ main (int    argc,
       if (!do_export (build_context, &error,
                       FALSE,
                       flatpak_file_get_path_cached (export_repo),
-                      app_dir_path, exclude_dirs, builder_manifest_get_branch (manifest),
+                      app_dir_path, exclude_dirs, builder_manifest_get_branch (manifest, build_context),
                       builder_manifest_get_collection_id (manifest),
                       "--exclude=/lib/debug/*",
                       "--include=/lib/debug/app",
@@ -1044,7 +1044,7 @@ main (int    argc,
                                    "/share/runtime/locale/", NULL);
           if (!do_export (build_context, &error, TRUE,
                           flatpak_file_get_path_cached (export_repo),
-                          app_dir_path, NULL, builder_manifest_get_branch (manifest),
+                          app_dir_path, NULL, builder_manifest_get_branch (manifest, build_context),
                           builder_manifest_get_collection_id (manifest),
                           metadata_arg,
                           files_arg,
@@ -1064,7 +1064,7 @@ main (int    argc,
 
           if (!do_export (build_context, &error, TRUE,
                           flatpak_file_get_path_cached (export_repo),
-                          app_dir_path, NULL, builder_manifest_get_branch (manifest),
+                          app_dir_path, NULL, builder_manifest_get_branch (manifest, build_context),
                           builder_manifest_get_collection_id (manifest),
                           "--metadata=metadata.debuginfo",
                           builder_context_get_build_runtime (build_context) ? "--files=usr/lib/debug" : "--files=files/lib/debug",
@@ -1095,7 +1095,7 @@ main (int    argc,
 
           if (!do_export (build_context, &error, TRUE,
                           flatpak_file_get_path_cached (export_repo),
-                          app_dir_path, NULL, builder_manifest_get_branch (manifest),
+                          app_dir_path, NULL, builder_manifest_get_branch (manifest, build_context),
                           builder_manifest_get_collection_id (manifest),
                           metadata_arg, files_arg,
                           NULL))
@@ -1114,7 +1114,7 @@ main (int    argc,
 
           if (!do_export (build_context, &error, TRUE,
                           flatpak_file_get_path_cached (export_repo),
-                          app_dir_path, NULL, builder_manifest_get_branch (manifest),
+                          app_dir_path, NULL, builder_manifest_get_branch (manifest, build_context),
                           builder_manifest_get_collection_id (manifest),
                           "--metadata=metadata.sources",
                           "--files=sources",
@@ -1134,7 +1134,7 @@ main (int    argc,
 
           if (!do_export (build_context, &error, TRUE,
                           flatpak_file_get_path_cached (export_repo),
-                          app_dir_path, NULL, builder_manifest_get_branch (manifest),
+                          app_dir_path, NULL, builder_manifest_get_branch (manifest, build_context),
                           builder_manifest_get_collection_id (manifest),
                           "--metadata=metadata.platform",
                           "--files=platform",
@@ -1168,7 +1168,7 @@ main (int    argc,
           files_arg = g_strconcat ("--files=platform/share/runtime/locale/", NULL);
           if (!do_export (build_context, &error, TRUE,
                           flatpak_file_get_path_cached (export_repo),
-                          app_dir_path, NULL, builder_manifest_get_branch (manifest),
+                          app_dir_path, NULL, builder_manifest_get_branch (manifest, build_context),
                           builder_manifest_get_collection_id (manifest),
                           metadata_arg,
                           files_arg,
@@ -1188,7 +1188,7 @@ main (int    argc,
         g_printerr ("NOTE: No export due to --require-changes, ignoring --install\n");
       else if (!do_install (build_context, flatpak_file_get_path_cached (export_repo),
                             builder_manifest_get_id (manifest),
-                            builder_manifest_get_branch (manifest),
+                            builder_manifest_get_branch (manifest, build_context),
                             &error))
         {
           g_printerr ("Install failed: %s\n", error->message);

--- a/src/builder-manifest.h
+++ b/src/builder-manifest.h
@@ -59,9 +59,8 @@ BuilderOptions *builder_manifest_get_build_options (BuilderManifest *self);
 GList *         builder_manifest_get_modules (BuilderManifest *self);
 GList *         builder_manifest_get_add_extensions (BuilderManifest *self);
 GList *         builder_manifest_get_add_build_extensions (BuilderManifest *self);
-const char *    builder_manifest_get_branch (BuilderManifest *self);
-void            builder_manifest_set_default_branch (BuilderManifest *self,
-                                                     const char *default_branch);
+const char *    builder_manifest_get_branch (BuilderManifest *self,
+                                             BuilderContext  *context);
 const char *    builder_manifest_get_collection_id (BuilderManifest *self);
 const char *    builder_manifest_get_extension_tag (BuilderManifest *self);
 void            builder_manifest_set_default_collection_id (BuilderManifest *self,


### PR DESCRIPTION
This is similar to branch and used if branch is not set. However, this
key (as opposed to branch) is overridden by the --default-branch option.

The idea is that most apps in flathub would use default-branch=stable, so
that a standart flatpak-builder command will build a "stable" release.
However, when building a test build we can use --default-branch=test to
override that. Then special cases like theme extensions and other things
that require a specific branch value to work at all can use branch="1.0".