### PR TITLE
Fixup error messages

### DIFF
--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -718,7 +718,7 @@ main (int    argc,
     {
       if (!builder_manifest_show_deps (manifest, build_context, &error))
         {
-          g_printerr ("Error running %s: %s\n", argv[3], error->message);
+          g_printerr ("Error calculating deps: %s\n", error->message);
           return 1;
         }
 
@@ -730,7 +730,7 @@ main (int    argc,
       if (!builder_manifest_install_deps (manifest, build_context, opt_install_deps_from, opt_user, opt_installation,
                                           opt_yes, &error))
         {
-          g_printerr ("Error running %s: %s\n", argv[3], error->message);
+          g_printerr ("Error installing deps: %s\n", error->message);
           return 1;
         }
       if (opt_install_deps_only)

--- a/src/builder-manifest.c
+++ b/src/builder-manifest.c
@@ -3701,7 +3701,11 @@ builder_manifest_install_dep (BuilderManifest *self,
   g_ptr_array_add (args, NULL);
 
   if (!builder_maybe_host_spawnv (NULL, NULL, 0, error, (const char * const *)args->pdata))
-    return FALSE;
+    {
+      g_autofree char *commandline = flatpak_quote_argv ((const char **)args->pdata);
+      g_prefix_error (error, "running `%s`: ", commandline);
+      return FALSE;
+    }
 
   return TRUE;
 }


### PR DESCRIPTION
We were printing argv[3] which is wrong (and typically null).
Instead set the error message where it happens and we know
what we were trying to do.