### PR TITLE
docs: Fix default value for script source's "dest-filename"

### DIFF
--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -824,7 +824,7 @@
                     </varlistentry>
                     <varlistentry>
                         <term><option>dest-filename</option> (string)</term>
-                        <listitem><para>Filename to use inside the source dir, default to the basename of path.</para></listitem>
+                        <listitem><para>Filename to use inside the source dir, default to autogen.sh.</para></listitem>
                     </varlistentry>
                 </variablelist>
             </refsect3>


### PR DESCRIPTION
The description for "dest-filename" was copy/pasted from the "file"
source's documentation for the same property. The default filename is
actually autogen.sh