### PR TITLE
Update platform creation to ensure good mtimes and better cacheing

### DIFF
--- a/src/builder-module.c
+++ b/src/builder-module.c
@@ -2010,9 +2010,9 @@ builder_module_checksum_for_cleanup (BuilderModule  *self,
 }
 
 void
-builder_module_checksum_for_platform (BuilderModule  *self,
-                                      BuilderCache   *cache,
-                                      BuilderContext *context)
+builder_module_checksum_for_platform_cleanup (BuilderModule  *self,
+                                              BuilderCache   *cache,
+                                              BuilderContext *context)
 {
   builder_cache_checksum_strv (cache, self->cleanup_platform);
 }

--- a/src/builder-module.h
+++ b/src/builder-module.h
@@ -89,9 +89,9 @@ void     builder_module_checksum (BuilderModule  *self,
 void     builder_module_checksum_for_cleanup (BuilderModule  *self,
                                               BuilderCache   *cache,
                                               BuilderContext *context);
-void     builder_module_checksum_for_platform (BuilderModule  *self,
-                                               BuilderCache   *cache,
-                                               BuilderContext *context);
+void     builder_module_checksum_for_platform_cleanup (BuilderModule  *self,
+                                                       BuilderCache   *cache,
+                                                       BuilderContext *context);
 void     builder_module_cleanup_collect (BuilderModule  *self,
                                          gboolean        platform,
                                          BuilderContext *context,


### PR DESCRIPTION
This splits the platform creation into 3 parts:
 * base - create the initial directory based on the parent platform
 * prepare - run prepare commands and apply all changes
 * cleanup - apply cleanups and cleanup commands

This has cacheing advantages in that prepare_commands and cleanup changes
only cause the minimal amount of rebuilds.

Additionally, it ensures that the mtimes are zeroed out (from the
previous checkout) both when the prepare and cleanup commands are run.
This is actually important, since these often generate caches (for
example fontconfig ones) which rely on zeroed mtimes so they match
what will be deployed.