### PR TITLE
utils: force exit host commands when flatpak-builder exits

### DIFF
--- a/src/builder-flatpak-utils.h
+++ b/src/builder-flatpak-utils.h
@@ -33,6 +33,7 @@
 
 typedef enum {
   FLATPAK_HOST_COMMAND_FLAGS_CLEAR_ENV = 1 << 0,
+  FLATPAK_HOST_COMMAND_FLAGS_WATCH_BUS = 1 << 1,
 } FlatpakHostCommandFlags;
 
 typedef void (*FlatpakLoadUriProgress) (guint64 downloaded_bytes,


### PR DESCRIPTION
If we are spawning applications on the host using the Development service,
then we want those commands to exit when the flatpak-builder process
exits, as can happen from Ctrl^C or kill().