### PR TITLE
Ensure shallow repo mirror is updated when the git ref changes

### DIFF
--- a/src/builder-git.c
+++ b/src/builder-git.c
@@ -531,8 +531,10 @@ builder_git_mirror_repo (const char     *repo_location,
       else
         cached_git_dir = g_object_ref (cache_mirror_dir);
 
-      /* If we're not updating, only pull from cache to avoid network i/o */
-      if (!update)
+      /* If the ref already exists (it may not with a shallow mirror
+       * if it has changed) and we're not updating, only pull from
+       * cache to avoid network i/o. */
+      if (already_exists && !update)
         {
           if (cached_git_dir)
             origin = g_file_get_uri (cached_git_dir);


### PR DESCRIPTION
Shallow clones only contain the ref that was cloned, and so if a
mirror is shallow and the ref is changed in a subsequent invocation of
builder, the new ref is absent and git fails with an error.

This patch avoids bailing out too soon when mirroring a repo if the
requested ref does not exist, to ensure it is fetched.

Fixes #285