### PR TITLE
Feature: Use CCACHE_DIR from environment, if set

### DIFF
--- a/doc/flatpak-builder.xml
+++ b/doc/flatpak-builder.xml
@@ -344,7 +344,8 @@
                 <term><option>--ccache</option></term>
 
                 <listitem><para>
-                     Enable use of ccache in the build (needs ccache in the sdk)
+                     Enable use of ccache in the build (needs ccache in the sdk). The default ccache folder can be
+                     overridden by setting the environment variable CCACHE_DIR.
                 </para></listitem>
             </varlistentry>
 

--- a/src/builder-context.c
+++ b/src/builder-context.c
@@ -202,7 +202,18 @@ builder_context_constructed (GObject *object)
   self->build_dir = g_file_get_child (self->state_dir, "build");
   self->cache_dir = g_file_get_child (self->state_dir, "cache");
   self->checksums_dir = g_file_get_child (self->state_dir, "checksums");
-  self->ccache_dir = g_file_get_child (self->state_dir, "ccache");
+
+  // Check, if CCACHE_DIR is set in environment and use it, instead of subdir of state_dir
+  const char * env_ccache_dir = g_getenv ("CCACHE_DIR");
+  if (env_ccache_dir && g_path_is_absolute(env_ccache_dir))
+    {
+      g_debug ("Using CCACHE_DIR '%s'", env_ccache_dir);
+      self->ccache_dir = g_file_new_for_path (env_ccache_dir);
+    }
+    else
+    {
+      self->ccache_dir = g_file_get_child(self->state_dir, "ccache");
+    }
 }
 
 static void


### PR DESCRIPTION
I'm using a Jenkins CI, which builds lots of things inside a docker container. Recently, flatpak-support was added to that container, so I  started using it. Very nice experience, so far - thanks a lot! :unicorn: 

The pipeline provides a large, shared ccache directory on a fast SSD using the standard `CCACHE_DIR` environment variable, however flatpak ignores it and places the ccache inside the state directory. I know one can change the location of the state directory, but this is IMHO too coarse. The size of the build dir is often a lot larger than a ccache. Symlinking the ccache dir won't work due to bind mounts.

This MR passes the directory configured in `CCACHE_DIR` to the sandbox, if the environment variable is set.