### PR TITLE
Use flatpak_spawnv() more

### DIFF
--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -198,7 +198,6 @@ do_export (BuilderContext *build_context,
   int i;
 
   g_autoptr(GPtrArray) args = NULL;
-  g_autoptr(GSubprocess) subp = NULL;
 
   args = g_ptr_array_new_with_free_func (g_free);
   g_ptr_array_add (args, g_strdup ("flatpak"));
@@ -244,16 +243,8 @@ do_export (BuilderContext *build_context,
 
   g_ptr_array_add (args, NULL);
 
-  subp =
-    g_subprocess_newv ((const gchar * const *) args->pdata,
-                       G_SUBPROCESS_FLAGS_NONE,
-                       error);
-
-  if (subp == NULL ||
-      !g_subprocess_wait_check (subp, NULL, error))
-    return FALSE;
-
-  return TRUE;
+  return flatpak_spawnv (NULL, NULL, G_SUBPROCESS_FLAGS_NONE, error,
+                         (const gchar * const *) args->pdata);
 }
 
 static gboolean
@@ -266,7 +257,6 @@ do_install (BuilderContext *build_context,
   g_autofree char *ref = NULL;
 
   g_autoptr(GPtrArray) args = NULL;
-  g_autoptr(GSubprocess) subp = NULL;
 
   args = g_ptr_array_new_with_free_func (g_free);
   g_ptr_array_add (args, g_strdup ("flatpak"));
@@ -292,16 +282,8 @@ do_install (BuilderContext *build_context,
 
   g_ptr_array_add (args, NULL);
 
-  subp =
-    g_subprocess_newv ((const gchar * const *) args->pdata,
-                       G_SUBPROCESS_FLAGS_NONE,
-                       error);
-
-  if (subp == NULL ||
-      !g_subprocess_wait_check (subp, NULL, error))
-    return FALSE;
-
-  return TRUE;
+  return flatpak_spawnv (NULL, NULL, G_SUBPROCESS_FLAGS_NONE, error,
+                         (const gchar * const *) args->pdata);
 }
 
 static gboolean

--- a/src/builder-manifest.c
+++ b/src/builder-manifest.c
@@ -1638,9 +1638,7 @@ builder_manifest_init_app_dir (BuilderManifest *self,
 {
   GFile *app_dir = builder_context_get_app_dir (context);
 
-  g_autoptr(GSubprocess) subp = NULL;
   g_autoptr(GPtrArray) args = NULL;
-  g_autofree char *commandline = NULL;
   GList *l;
   int i;
 
@@ -1723,16 +1721,8 @@ builder_manifest_init_app_dir (BuilderManifest *self,
   g_ptr_array_add (args, g_strdup (builder_manifest_get_runtime_version (self)));
   g_ptr_array_add (args, NULL);
 
-  commandline = flatpak_quote_argv ((const char **) args->pdata);
-  g_debug ("Running '%s'", commandline);
-
-  subp =
-    g_subprocess_newv ((const gchar * const *) args->pdata,
-                       G_SUBPROCESS_FLAGS_NONE,
-                       error);
-
-  if (subp == NULL ||
-      !g_subprocess_wait_check (subp, NULL, error))
+  if (!flatpak_spawnv (NULL, NULL, G_SUBPROCESS_FLAGS_NONE, error,
+                       (const gchar * const *) args->pdata))
     return FALSE;
 
   if (self->build_runtime && self->separate_locales)
@@ -2760,10 +2750,8 @@ builder_manifest_finish (BuilderManifest *self,
   g_autoptr(GFile) sources_dir = NULL;
   g_autoptr(GFile) locale_parent_dir = NULL;
   g_autofree char *json = NULL;
-  g_autofree char *commandline = NULL;
   g_autoptr(GPtrArray) args = NULL;
   g_autoptr(GPtrArray) inherit_extensions = NULL;
-  g_autoptr(GSubprocess) subp = NULL;
   int i;
   GList *l;
 
@@ -2956,16 +2944,8 @@ builder_manifest_finish (BuilderManifest *self,
       g_ptr_array_add (args, g_file_get_path (app_dir));
       g_ptr_array_add (args, NULL);
 
-      commandline = flatpak_quote_argv ((const char **) args->pdata);
-      g_debug ("Running '%s'", commandline);
-
-      subp =
-        g_subprocess_newv ((const gchar * const *) args->pdata,
-                           G_SUBPROCESS_FLAGS_NONE,
-                           error);
-
-      if (subp == NULL ||
-          !g_subprocess_wait_check (subp, NULL, error))
+      if (!flatpak_spawnv (NULL, NULL, G_SUBPROCESS_FLAGS_NONE, error,
+                           (const gchar * const *) args->pdata))
         return FALSE;
 
       json = builder_manifest_serialize (self);
@@ -3178,9 +3158,7 @@ builder_manifest_create_platform_base (BuilderManifest *self,
     {
       GFile *app_dir = NULL;
       g_autoptr(GFile) platform_dir = NULL;
-      g_autoptr(GSubprocess) subp = NULL;
       g_autoptr(GPtrArray) args = NULL;
-      g_autofree char *commandline = NULL;
       int i;
 
       g_print ("Creating platform based on %s\n", self->runtime);
@@ -3216,16 +3194,8 @@ builder_manifest_create_platform_base (BuilderManifest *self,
 
       g_ptr_array_add (args, NULL);
 
-      commandline = flatpak_quote_argv ((const char **) args->pdata);
-      g_debug ("Running '%s'", commandline);
-
-      subp =
-        g_subprocess_newv ((const gchar * const *) args->pdata,
-                           G_SUBPROCESS_FLAGS_NONE,
-                           error);
-
-      if (subp == NULL ||
-          !g_subprocess_wait_check (subp, NULL, error))
+      if (!flatpak_spawnv (NULL, NULL, G_SUBPROCESS_FLAGS_NONE, error,
+                           (const gchar * const *) args->pdata))
         return FALSE;
 
       if (self->separate_locales)


### PR DESCRIPTION
This means when flatpak-builder runs a flatpak command in a subprocess,
we can see the arguments passed to flatpak in the flatpak-builder
output, if -v was used.