### PR TITLE
Some YAML parsing fixes

### DIFF
--- a/src/builder-module.c
+++ b/src/builder-module.c
@@ -749,7 +749,7 @@ load_sources_from_json (const char *sources_relpath)
     }
 
   builder_manifest_set_demarshal_base_dir (sources_file_dir);
-  sources_root = json_from_string (sources_json, &error);
+  sources_root = builder_json_node_from_data (sources_path, sources_json, &error);
   if (sources_root == NULL)
     {
       g_printerr ("Error parsing %s: %s\n", sources_relpath, error->message);

--- a/src/builder-utils.c
+++ b/src/builder-utils.c
@@ -423,7 +423,8 @@ parse_yaml_node_to_json (yaml_document_t *doc, yaml_node_t *node)
                   json_node_init_int (json, num);
                   break;
                 }
-              else if (*endptr == '.')
+              // Make sure that N.N, N., and .N (where N is a digit) are picked up as numbers.
+              else if (*endptr == '.' && (endptr != scalar || endptr[1] != '\0'))
                 {
                   g_ascii_strtoll (endptr + 1, &endptr, 10);
                   if (*endptr == '\0')

--- a/src/builder-utils.c
+++ b/src/builder-utils.c
@@ -509,22 +509,28 @@ parse_yaml_to_json (const gchar *contents,
 
 #endif  // FLATPAK_BUILDER_ENABLE_YAML
 
+JsonNode *
+builder_json_node_from_data (const char *relpath,
+                             const char *contents,
+                             GError    **error)
+{
+  if (g_str_has_suffix (relpath, ".yaml") || g_str_has_suffix (relpath, ".yml"))
+    return parse_yaml_to_json (contents, error);
+  else
+    return json_from_string (contents, error);
+}
+
 GObject *
 builder_gobject_from_data (GType       gtype,
                            const char *relpath,
                            const char *contents,
                            GError    **error)
 {
-  if (g_str_has_suffix (relpath, ".yaml") || g_str_has_suffix (relpath, ".yml"))
-    {
-      g_autoptr(JsonNode) json = parse_yaml_to_json (contents, error);
-      if (json != NULL)
-        return json_gobject_deserialize (gtype, json);
-      else
-        return NULL;
-    }
+  g_autoptr(JsonNode) json = builder_json_node_from_data (relpath, contents, error);
+  if (json != NULL)
+    return json_gobject_deserialize (gtype, json);
   else
-    return json_gobject_from_data (gtype, contents, -1, error);
+    return NULL;
 }
 
 /*

--- a/src/builder-utils.h
+++ b/src/builder-utils.h
@@ -68,6 +68,10 @@ GQuark builder_curl_error_quark (void);
 GQuark builder_yaml_parse_error_quark (void);
 #define BUILDER_YAML_PARSE_ERROR (builder_yaml_parse_error_quark ())
 
+JsonNode * builder_json_node_from_data (const char *relpath,
+                                        const char *contents,
+                                        GError    **error);
+
 GObject * builder_gobject_from_data (GType       gtype,
                                      const char *relpath,
                                      const char *contents,


### PR DESCRIPTION
- Support parsing sources files as YAML, fixes #297.
- Fix for the YAML number warning treating `.` as a number. YAML's number parsing is weird...

What dark universe is this that the main, flexible configuration languages are either too strict to be easily writable or too lax to be easily parsable? /shrug