### PR TITLE
Support --show-manifest

### DIFF
--- a/doc/flatpak-builder.xml
+++ b/doc/flatpak-builder.xml
@@ -49,6 +49,12 @@
                 <arg choice="opt" rep="repeat">OPTION</arg>
                 <arg choice="plain">MANIFEST</arg>
             </cmdsynopsis>
+            <cmdsynopsis>
+                <command>flatpak-builder</command>
+                <arg choice="plain">--show-manifest</arg>
+                <arg choice="opt" rep="repeat">OPTION</arg>
+                <arg choice="plain">MANIFEST</arg>
+            </cmdsynopsis>
     </refsynopsisdiv>
 
     <refsect1>
@@ -244,6 +250,23 @@
 
                 <listitem><para>
                   List all the (local) files that the manifest depends on.
+                  </para>
+
+                  <para>
+                  Only the <option>--verbose</option> option can be combined
+                  with this option.
+                  </para>
+                </listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--show-manifest</option></term>
+
+                <listitem><para>
+                  Loads the manifest, including any included files and prints it in a canonical json format.
+                  This is useful for tools that want to handle manifest files to avoid having to support both
+                  yaml and json, as well as some non-standard json handling that is supported (for example
+                  comments and multiline strings).
                   </para>
 
                   <para>

--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -154,13 +154,13 @@ static GOptionEntry run_entries[] = {
 
 static GOptionEntry show_deps_entries[] = {
   { "verbose", 'v', 0, G_OPTION_ARG_NONE, &opt_verbose, "Print debug information during command processing", NULL },
-  { "show-deps", 0, 0, G_OPTION_ARG_NONE, &opt_show_deps, "List the dependencies of the json file (see --show-deps --help)", NULL },
+  { "show-deps", 0, 0, G_OPTION_ARG_NONE, &opt_show_deps, "List the dependencies of the json file", NULL },
   { NULL }
 };
 
 static GOptionEntry show_manifest_entries[] = {
   { "verbose", 'v', 0, G_OPTION_ARG_NONE, &opt_verbose, "Print debug information during command processing", NULL },
-  { "show-manifest", 0, 0, G_OPTION_ARG_NONE, &opt_show_manifest, "Print out the manifest file in standard json format (see --show-manifest --help)", NULL },
+  { "show-manifest", 0, 0, G_OPTION_ARG_NONE, &opt_show_manifest, "Print out the manifest file in standard json format", NULL },
   { NULL }
 };
 
@@ -692,7 +692,7 @@ main (int    argc,
   if (is_show_manifest)
     {
       g_autofree char *json = builder_manifest_serialize (manifest);
-      g_print ("%s", json);
+      g_print ("%s\n", json);
       return 0;
     }
 

--- a/src/builder-manifest.c
+++ b/src/builder-manifest.c
@@ -1289,7 +1289,7 @@ serializable_iface_init (JsonSerializableIface *serializable_iface)
   serializable_iface->get_property = builder_serializable_get_property;
 }
 
-static char *
+char *
 builder_manifest_serialize (BuilderManifest *self)
 {
   JsonNode *node;

--- a/src/builder-manifest.h
+++ b/src/builder-manifest.h
@@ -134,6 +134,7 @@ gboolean        builder_manifest_create_platform (BuilderManifest *self,
                                                   BuilderCache    *cache,
                                                   BuilderContext  *context,
                                                   GError         **error);
+char *          builder_manifest_serialize       (BuilderManifest *self);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (BuilderManifest, g_object_unref)
 


### PR DESCRIPTION
We want to use this in flathub to avoid all the problems we've having
parsing json manifests via the python parser, which isn't *quite* compatible
with json-glib (differs in comment and multiline string support for instance).