### PR TITLE
Support duplicate module names

### DIFF
--- a/src/builder-module.c
+++ b/src/builder-module.c
@@ -936,6 +936,14 @@ builder_module_get_name (BuilderModule *self)
   return self->name;
 }
 
+void
+builder_module_set_name (BuilderModule *self,
+                         const char *name)
+{
+  g_free (self->name);
+  self->name = g_strdup (name);
+}
+
 gboolean
 builder_module_is_enabled (BuilderModule *self,
                            BuilderContext *context)

--- a/src/builder-module.h
+++ b/src/builder-module.h
@@ -40,6 +40,8 @@ typedef struct BuilderModule BuilderModule;
 GType builder_module_get_type (void);
 
 const char * builder_module_get_name (BuilderModule *self);
+void         builder_module_set_name (BuilderModule *self,
+                                      const char *name);
 gboolean     builder_module_is_enabled (BuilderModule *self,
                                         BuilderContext *context);
 gboolean     builder_module_get_disabled (BuilderModule *self);


### PR DESCRIPTION
If two modules happen to have the same name we uniquify them by appending "-$n". While you shouldn't normally rely on this it is sometimes hard to avoid when you're including some json snippet you don't have control over.
