### PR TITLE
Support passing --token-type to build-export

### DIFF
--- a/doc/flatpak-builder.xml
+++ b/doc/flatpak-builder.xml
@@ -429,6 +429,19 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--token-type=VAL</option></term>
+
+                <listitem><para>
+                    Set type of token needed to install this commit.
+                    Setting this to a value greater than 0 implies that
+                    authentication will be needed to install the
+                    flatpak. A <option>token-type</option> property set
+                    in the manifest takes precedence over this option.
+                    Used when exporting the build results.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>--gpg-sign=KEYID</option></term>
 
                 <listitem><para>

--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -102,6 +102,13 @@
                     then an error will occur.</para></listitem>
                 </varlistentry>
                 <varlistentry>
+                    <term><option>token-type</option> (integer)</term>
+                    <listitem><para>The type of token needed to install
+                    this commit. Setting this to a value greater than 0
+                    implies that authentication will be needed to
+                    install the flatpak.</para></listitem>
+                </varlistentry>
+                <varlistentry>
                     <term><option>runtime</option> (string)</term>
                     <listitem><para>The name of the runtime that the application uses.</para></listitem>
                 </varlistentry>

--- a/src/builder-manifest.c
+++ b/src/builder-manifest.c
@@ -63,6 +63,7 @@ struct BuilderManifest
   char           *branch;
   char           *default_branch;
   char           *collection_id;
+  gint32          token_type;
   char           *extension_tag;
   char           *type;
   char           *runtime;
@@ -167,6 +168,7 @@ enum {
   PROP_ADD_EXTENSIONS,
   PROP_ADD_BUILD_EXTENSIONS,
   PROP_EXTENSION_TAG,
+  PROP_TOKEN_TYPE,
   LAST_PROP
 };
 
@@ -470,6 +472,10 @@ builder_manifest_get_property (GObject    *object,
       g_value_set_string (value, self->extension_tag);
       break;
 
+    case PROP_TOKEN_TYPE:
+      g_value_set_int (value, (int)self->token_type);
+      break;
+
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
@@ -727,6 +733,10 @@ builder_manifest_set_property (GObject      *object,
     case PROP_EXTENSION_TAG:
       g_free (self->extension_tag);
       self->extension_tag = g_value_dup_string (value);
+      break;
+
+    case PROP_TOKEN_TYPE:
+      self->token_type = (gint32)g_value_get_int (value);
       break;
 
     default:
@@ -1070,11 +1080,22 @@ builder_manifest_class_init (BuilderManifestClass *klass)
                                                         "",
                                                         NULL,
                                                         G_PARAM_READWRITE));
+
+  g_object_class_install_property (object_class,
+                                   PROP_TOKEN_TYPE,
+                                   g_param_spec_int ("token-type",
+                                                     "",
+                                                     "",
+                                                     -1,
+                                                     G_MAXINT32,
+                                                     -1,
+                                                     G_PARAM_READWRITE));
 }
 
 static void
 builder_manifest_init (BuilderManifest *self)
 {
+  self->token_type = -1;
   self->appstream_compose = TRUE;
   self->separate_locales = TRUE;
 }
@@ -1424,6 +1445,20 @@ builder_manifest_set_default_collection_id (BuilderManifest *self,
 {
   if (self->collection_id == NULL)
     self->collection_id = g_strdup (default_collection_id);
+}
+
+gint32
+builder_manifest_get_token_type (BuilderManifest *self)
+{
+  return self->token_type;
+}
+
+void
+builder_manifest_set_default_token_type (BuilderManifest *self,
+                                         gint32           default_token_type)
+{
+  if (self->token_type == -1)
+    self->token_type = default_token_type;
 }
 
 void

--- a/src/builder-manifest.h
+++ b/src/builder-manifest.h
@@ -62,9 +62,12 @@ GList *         builder_manifest_get_add_build_extensions (BuilderManifest *self
 const char *    builder_manifest_get_branch (BuilderManifest *self,
                                              BuilderContext  *context);
 const char *    builder_manifest_get_collection_id (BuilderManifest *self);
+gint32          builder_manifest_get_token_type (BuilderManifest *self);
 const char *    builder_manifest_get_extension_tag (BuilderManifest *self);
 void            builder_manifest_set_default_collection_id (BuilderManifest *self,
                                                             const char      *default_collection_id);
+void            builder_manifest_set_default_token_type (BuilderManifest *self,
+                                                         gint32           default_token_type);
 
 void            builder_manifest_add_tags (BuilderManifest *self,
                                            const char      **add_tags);

--- a/tests/test.json
+++ b/tests/test.json
@@ -4,6 +4,7 @@
     "sdk": "org.test.Sdk",
     "command": "hello2.sh",
     "tags": ["test"],
+    "token-type": 0,
     "finish-args": [
         "--share=network"
     ],

--- a/tests/test.yaml
+++ b/tests/test.yaml
@@ -3,6 +3,7 @@ runtime: org.test.Platform
 sdk: org.test.Sdk
 command: hello2.sh
 tags: [test]
+token-type: 0
 finish-args:
   - --share=network
 build-options:


### PR DESCRIPTION
Provide a --token-type command line option and a token-type manifest
property that allows passing the token type to build-export. The
manifest property takes precendence over the CLI option. In either case,
the value will be passed to build-export if it's >= 0. This requires
flatpak >= 1.6 to use the --token-type option in build-export.