### PR TITLE
bzr: Run brz in preference to bzr

### DIFF
--- a/src/builder-source-bzr.c
+++ b/src/builder-source-bzr.c
@@ -120,11 +120,14 @@ bzr (GFile   *dir,
      GError **error,
      ...)
 {
+  g_autofree char *brz = NULL;
   gboolean res;
   va_list ap;
 
+  brz = g_find_program_in_path ("brz");
+
   va_start (ap, error);
-  res = flatpak_spawn (dir, output, 0, error, "bzr", ap);
+  res = flatpak_spawn (dir, output, 0, error, brz ? brz : "bzr", ap);
   va_end (ap);
 
   return res;


### PR DESCRIPTION
Bazaar-NG (bzr) relies on Python 2, which has reached end-of-life, and
appears to be essentially unmaintained itself. Try using Breezy (brz),
a "friendly fork" of bzr that has been ported to Python 3 and is
maintained.