### PR TITLE
cache: sanity check the subject in builder_cache_lookup

### DIFF
--- a/src/builder-cache.c
+++ b/src/builder-cache.c
@@ -418,7 +418,7 @@ builder_cache_lookup (BuilderCache *self,
       g_variant_get (variant, "(a{sv}aya(say)&s&stayay)", NULL, NULL, NULL,
                      &subject, NULL, NULL, NULL, NULL);
 
-      if (strcmp (subject, self->current_checksum) == 0)
+      if (subject != NULL && strcmp (subject, self->current_checksum) == 0)
         {
           g_free (self->last_parent);
           self->last_parent = g_steal_pointer (&commit);

--- a/src/builder-cache.c
+++ b/src/builder-cache.c
@@ -418,7 +418,7 @@ builder_cache_lookup (BuilderCache *self,
       g_variant_get (variant, "(a{sv}aya(say)&s&stayay)", NULL, NULL, NULL,
                      &subject, NULL, NULL, NULL, NULL);
 
-      if (subject != NULL && strcmp (subject, self->current_checksum) == 0)
+      if (g_strcmp0 (subject, self->current_checksum) == 0)
         {
           g_free (self->last_parent);
           self->last_parent = g_steal_pointer (&commit);


### PR DESCRIPTION
When the cache is broken, the variant from ostree is not
a reliable source of information. The variant may thus fail to
be extracted.

I had a crash after my btrfs decided to mess up my filesystem:

```
gdb --args flatpak-builder --install --user --install-deps-from=flathub  --ccache --keep-build-dirs  --force-clean -v  --repo=/var/tmp/fb.repo fpbuilder org.signal.Signal2.json 
GNU gdb (Ubuntu 8.1-0ubuntu3.2) 8.1.0.20180409-git
Copyright (C) 2018 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
<http://www.gnu.org/software/gdb/documentation/>.
For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from flatpak-builder...Reading symbols from /usr/lib/debug/.build-id/17/9f6220cad76a10f23b9c45d9fb4efd2234adf6.debug...done.
done.
(gdb) r
Starting program: /usr/bin/flatpak-builder --install --user --install-deps-from=flathub --ccache --keep-build-dirs --force-clean -v --repo=/var/tmp/fb.repo fpbuilder org.signal.Signal2.json
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
FB: Running: git config --get user.email
[New Thread 0x7fffeb08c700 (LWP 3670)]
FB: Running: git config --get user.name
Dependency Sdk: org.freedesktop.Sdk 19.08
FB: Running: flatpak --user info org.freedesktop.Sdk/x86_64/19.08 --show-commit
Updating org.freedesktop.Sdk/x86_64/19.08
FB: Using Flatpak version 1.7.2
FB: Running: flatpak --user update --subpath= -y --noninteractive org.freedesktop.Sdk/x86_64/19.08
Nothing to do.
Dependency Runtime: org.freedesktop.Platform 19.08
FB: Running: flatpak --user info org.freedesktop.Platform/x86_64/19.08 --show-commit
Updating org.freedesktop.Platform/x86_64/19.08
FB: Running: flatpak --user update --subpath= -y --noninteractive org.freedesktop.Platform/x86_64/19.08
Nothing to do.
Dependency Base: org.electronjs.Electron2.BaseApp 19.08
FB: Running: flatpak --user info org.electronjs.Electron2.BaseApp/x86_64/19.08 --show-commit
Updating org.electronjs.Electron2.BaseApp/x86_64/19.08
FB: Running: flatpak --user update --subpath= -y --noninteractive org.electronjs.Electron2.BaseApp/x86_64/19.08
Nothing to do.
FB: Running: flatpak info --arch=x86_64 --show-commit org.freedesktop.Sdk 19.08
FB: Running: flatpak info --show-location --arch=x86_64 org.freedesktop.Sdk 19.08
FB: Running: flatpak info --arch=x86_64 --show-commit org.freedesktop.Platform 19.08
FB: Running: flatpak info --arch=x86_64 --show-commit org.electronjs.Electron2.BaseApp 19.08
Downloading sources

Thread 1 "flatpak-builder" received signal SIGSEGV, Segmentation fault.
__strcmp_sse2_unaligned ()
    at ../sysdeps/x86_64/multiarch/strcmp-sse2-unaligned.S:31
31	../sysdeps/x86_64/multiarch/strcmp-sse2-unaligned.S: No such file or directory.
(gdb) bt
#0  0x00007ffff5d2fe8a in __strcmp_sse2_unaligned ()
    at ../sysdeps/x86_64/multiarch/strcmp-sse2-unaligned.S:31
#1  0x0000555555584f11 in builder_cache_lookup (self=0x55555581b8b0, stage=<optimised out>) at src/builder-cache.c:421
#2  0x0000555555564663 in main (argc=<optimised out>, argv=<optimised out>)
    at src/builder-main.c:872
(gdb) up
#1  0x0000555555584f11 in builder_cache_lookup (self=0x55555581b8b0, 
    stage=<optimised out>) at src/builder-cache.c:421
421	src/builder-cache.c: No such file or directory.
(gdb) l
416	in src/builder-cache.c
(gdb) 
```