### PR TITLE
Ignore the `--metadata` argument of flatpak build-finish

### DIFF
--- a/src/builder-manifest.c
+++ b/src/builder-manifest.c
@@ -4135,7 +4135,8 @@ builder_manifest_run (BuilderManifest *self,
               !g_str_has_prefix (arg, "--runtime") &&
               !g_str_has_prefix (arg, "--command") &&
               !g_str_has_prefix (arg, "--extra-data") &&
-              !g_str_has_prefix (arg, "--require-version"))
+              !g_str_has_prefix (arg, "--require-version") &&
+              !g_str_has_prefix (arg, "--metadata"))
             g_ptr_array_add (args, g_strdup (arg));
         }
     }


### PR DESCRIPTION
An app may use `--metadata` in the `finish-args` section to
add section/key/value entries in the metadata file.

If we pass this through to `flatpak build`, it's interpreted to
be a filename. Since it's not a filename, this leads to the
metadata file not being found, and an error is raised like this:

    /home/sam/src/gnome-photos/.flatpak-builder/rofiles/rofiles-qtBvVQ not initialized, use flatpak build-init