### PR TITLE
Don't extract git submodules if not mirrored

### DIFF
--- a/src/builder-git.c
+++ b/src/builder-git.c
@@ -828,6 +828,7 @@ builder_git_checkout (const char     *repo_location,
                       const char     *branch,
                       GFile          *dest,
                       BuilderContext *context,
+                      FlatpakGitMirrorFlags mirror_flags,
                       GError        **error)
 {
   g_autoptr(GFile) mirror_dir = NULL;
@@ -857,8 +858,9 @@ builder_git_checkout (const char     *repo_location,
             "checkout", branch, NULL))
     return FALSE;
 
-  if (!git_extract_submodule (repo_location, dest, branch, context, error))
-    return FALSE;
+  if (mirror_flags & FLATPAK_GIT_MIRROR_FLAGS_MIRROR_SUBMODULES)
+    if (!git_extract_submodule (repo_location, dest, branch, context, error))
+      return FALSE;
 
   return TRUE;
 }

--- a/src/builder-git.h
+++ b/src/builder-git.h
@@ -48,6 +48,7 @@ gboolean builder_git_checkout           (const char      *repo_location,
                                          const char      *branch,
                                          GFile           *dest,
                                          BuilderContext  *context,
+                                         FlatpakGitMirrorFlags mirror_flags,
                                          GError         **error);
 gboolean builder_git_shallow_mirror_ref (const char     *repo_location,
                                          const char     *destination_path,

--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -621,6 +621,7 @@ main (int    argc,
                                  git_branch,
                                  build_subdir,
                                  build_context,
+                                 mirror_flags,
                                  &error))
         {
           g_printerr ("Can't check out manifest repo: %s\n", error->message);

--- a/src/builder-source-git.c
+++ b/src/builder-source-git.c
@@ -285,13 +285,17 @@ builder_source_git_extract (BuilderSource  *source,
 {
   BuilderSourceGit *self = BUILDER_SOURCE_GIT (source);
   g_autofree char *location = NULL;
+  FlatpakGitMirrorFlags mirror_flags = 0;
 
   location = get_url_or_path (self, context, error);
   if (location == NULL)
     return FALSE;
 
+  if (!self->disable_submodules)
+    mirror_flags |= FLATPAK_GIT_MIRROR_FLAGS_MIRROR_SUBMODULES;
+
   if (!builder_git_checkout (location, get_branch (self),
-                             dest, context, error))
+                             dest, context, mirror_flags, error))
     return FALSE;
 
   return TRUE;


### PR DESCRIPTION
Pass `_MIRROR_SUBMODULES` flag to `builder_git_checkout()`, so that we don't try to extract submodules if they the were disabled.
It's entirely possible that I've got everything wrong, but this seems to work.
Fixes #337