### PR TITLE
Normalize rofiles-fuse related logs.

### DIFF
--- a/src/builder-context.c
+++ b/src/builder-context.c
@@ -770,7 +770,7 @@ rofiles_umount_handler (int signum)
                      NULL };
 
   argv[2] = rofiles_unmount_path;
-  g_debug ("unmounting rofiles-fuse %s", rofiles_unmount_path);
+  g_debug ("Unmounting read-only fs: %s %s %s", argv[0], argv[1], argv[2]);
   g_spawn_sync (NULL, (char **)argv, NULL,
                 G_SPAWN_SEARCH_PATH | G_SPAWN_CLOEXEC_PIPES | G_SPAWN_STDOUT_TO_DEV_NULL | G_SPAWN_STDERR_TO_DEV_NULL,
                 NULL, NULL, NULL, NULL, NULL, NULL);
@@ -874,7 +874,7 @@ builder_context_enable_rofiles (BuilderContext *self,
   rofiles_dir = g_object_ref (self->rofiles_allocated_dir);
   argv[4] = (char *)flatpak_file_get_path_cached (rofiles_dir);
 
-  g_debug ("starting: rofiles-fuse %s %s", argv[3], argv[4]);
+  g_debug ("Mounting read-only fs: %s %s %s", argv[0], argv[3], argv[4]);
   if (!g_spawn_sync (NULL, (char **)argv, NULL, G_SPAWN_SEARCH_PATH | G_SPAWN_CLOEXEC_PIPES, rofiles_child_setup, NULL, NULL, NULL, &exit_status, error))
     {
       g_prefix_error (error, "Can't spawn rofiles-fuse");

--- a/src/builder-flatpak-utils.c
+++ b/src/builder-flatpak-utils.c
@@ -1173,7 +1173,7 @@ const char *dont_mount_in_root[] = {
 };
 
 /* We don't want to export paths pointing into these, because they are readonly
-   (so we can't create mountpoints there) and don't match whats on the host anyway */
+   (so we can't create mountpoints there) and don't match what's on the host anyway */
 const char *dont_export_in[] = {
   "/lib", "/lib32", "/lib64", "/bin", "/sbin", "/usr", "/etc", "/app", NULL
 };


### PR DESCRIPTION
The actual command for unmounting the rofs was not printed, as opposed
to the command to mount the fs. The format of the message is also
normalized for easier debugging.

@alexlarsson thx for reviewing!