### PR TITLE
Port to meson

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,6 +8,10 @@ on:
     branches:
     - main
 
+env:
+  DEBIAN_FRONTEND: noninteractive
+  TESTS_TIMEOUT: 10 # in minutes
+
 jobs:
   check:
     name: Build with gcc and test

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,7 @@ env:
   TESTS_TIMEOUT: 10 # in minutes
 
 jobs:
-  check:
+  check-autotools:
     name: Build with gcc and test
     runs-on: ubuntu-22.04
     steps:
@@ -67,3 +67,87 @@ jobs:
         CFLAGS: -Werror=unused-variable
     - name: Build flatpak
       run: make -j $(getconf _NPROCESSORS_ONLN)
+
+  check-meson:
+    name: Ubuntu 22.04 meson build
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        compiler: ['gcc', 'clang']
+
+    env:
+      UBUNTU_VERSION: '22.04'
+      CC: ${{ matrix.compiler }}
+      BASE_CFLAGS: -Wp,-D_FORTIFY_SOURCE=2
+      BUILDDIR: builddir
+
+    steps:
+    - name: Install Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get upgrade -y
+        sudo apt-get install -y \
+          ${{ matrix.compiler }} \
+          attr \
+          automake \
+          autopoint \
+          bison \
+          debugedit \
+          dbus \
+          desktop-file-utils \
+          elfutils \
+          flatpak \
+          gettext \
+          git \
+          gobject-introspection \
+          gtk-doc-tools \
+          libappstream-glib-dev \
+          libarchive-dev \
+          libattr1-dev \
+          libcap-dev \
+          libcurl4-gnutls-dev \
+          libdconf-dev \
+          libdw-dev \
+          libelf-dev \
+          libflatpak-dev \
+          libfuse-dev \
+          libgirepository1.0-dev \
+          libglib2.0-dev \
+          libgpgme11-dev \
+          libjson-glib-dev \
+          libostree-dev \
+          libpolkit-agent-1-dev \
+          libpolkit-gobject-1-dev \
+          libseccomp-dev \
+          libsoup2.4-dev \
+          libsystemd-dev \
+          libxml2-utils \
+          libyaml-dev \
+          meson \
+          ostree \
+          patch \
+          shared-mime-info \
+          socat \
+          unzip
+
+    - name: Check out flatpak-builder
+      uses: actions/checkout@v2
+
+    - name: Configure flatpak-builder
+      # TODO: Enable gtk-doc builds
+      run: meson . ${BUILDDIR}
+
+    - name: Build flatpak-builder with Meson
+      run: meson compile -C ${BUILDDIR}
+
+    - name: Run tests with Meson
+      run: timeout --signal=KILL -v ${TESTS_TIMEOUT}m meson test -C ${BUILDDIR} --verbose
+
+    - name: Upload test logs
+      uses: actions/upload-artifact@v2
+      if: failure() || cancelled()
+      with:
+        name: test logs
+        path: |
+          builddir/meson-logs/testlog.txt
+          installed-test-logs/

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,7 +23,7 @@ jobs:
         sudo apt-get install -y libglib2.0 attr automake gettext autopoint bison  dbus gtk-doc-tools \
         libfuse-dev ostree libostree-dev libarchive-dev libcap-dev libattr1-dev libdw-dev libelf-dev \
         libjson-glib-dev shared-mime-info desktop-file-utils libpolkit-agent-1-dev libpolkit-gobject-1-dev \
-        libseccomp-dev libsoup2.4-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
+        libseccomp-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
         libgirepository1.0-dev libappstream-glib-dev libdconf-dev clang socat flatpak \
         libcurl4-gnutls-dev libflatpak-dev libyaml-dev elfutils git patch unzip
     - name: Check out flatpak
@@ -52,7 +52,7 @@ jobs:
         sudo apt-get install -y libglib2.0 attr automake gettext autopoint bison  dbus gtk-doc-tools \
         libfuse-dev ostree libostree-dev libarchive-dev libcap-dev libattr1-dev libdw-dev libelf-dev \
         libjson-glib-dev shared-mime-info desktop-file-utils libpolkit-agent-1-dev libpolkit-gobject-1-dev \
-        libseccomp-dev libsoup2.4-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
+        libseccomp-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
         libgirepository1.0-dev libappstream-glib-dev libdconf-dev clang flatpak \
         libcurl4-gnutls-dev libflatpak-dev libyaml-dev elfutils git patch unzip
     - name: Check out flatpak
@@ -119,7 +119,6 @@ jobs:
           libpolkit-agent-1-dev \
           libpolkit-gobject-1-dev \
           libseccomp-dev \
-          libsoup2.4-dev \
           libsystemd-dev \
           libxml2-utils \
           libyaml-dev \

--- a/.gitignore
+++ b/.gitignore
@@ -103,4 +103,3 @@ system-helper/org.freedesktop.Flatpak.policy
 system-helper/org.freedesktop.Flatpak.rules
 flatpak-bwrap
 py-compile
-/subprojects/libglnx/

--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,4 @@ system-helper/org.freedesktop.Flatpak.policy
 system-helper/org.freedesktop.Flatpak.rules
 flatpak-bwrap
 py-compile
+/subprojects/libglnx/

--- a/Makefile.am
+++ b/Makefile.am
@@ -80,7 +80,14 @@ flatpak_builder_debugedit_CFLAGS =		\
 
 endif # !WITH_SYSTEM_DEBUGEDIT
 
-EXTRA_DIST += README.md
+EXTRA_DIST += 			\
+	README.md		\
+	meson.build		\
+	meson_options.txt	\
+	data/meson.build	\
+	doc/meson.build		\
+	src/meson.build		\
+	$(NULL)
 
 AM_DISTCHECK_CONFIGURE_FLAGS =		\
 	--enable-documentation		\

--- a/Makefile.am
+++ b/Makefile.am
@@ -84,9 +84,11 @@ EXTRA_DIST += 			\
 	README.md		\
 	meson.build		\
 	meson_options.txt	\
-	data/meson.build	\
 	doc/meson.build		\
 	src/meson.build		\
+	tests/meson.build \
+	subprojects/libglnx.wrap \
+	subprojects/libyaml.wrap \
 	$(NULL)
 
 AM_DISTCHECK_CONFIGURE_FLAGS =		\

--- a/README.md
+++ b/README.md
@@ -8,16 +8,33 @@ See http://flatpak.org/ for more information.
 
 Read documentation for the flatpak-builder [commandline tools](http://docs.flatpak.org/en/latest/flatpak-builder-command-reference.html).
 
-# INSTALLATION
+# Installation
 
-Flatpak-builder uses a traditional autoconf-style build mechanism. To build just do
+Flatpak-builder uses a the Meson build system. To build just do:
 ```
- ./configure [args]
- make
- make install
+ ./meson . _build [args]
+ ninja -C _build
+ ninja -C _build install
 ```
 
-Most configure arguments are documented in `./configure --help`. However,
-there are some options that are a bit more complicated.
+Configure arguments are documented in `meson_options.txt`.
+
+Flatpak-builder depends on the following executables being present in the
+host system:
+
+ * tar
+ * unzip
+ * sh
+ * patch
+ * cp
+
+Optionally, flatpak-builder may try to execute the following programs if the
+manifest file requires:
+
+ * bzr
+ * git
+ * rpm2cpio & cpio
+ * svn
+ * 7z
 
 Flatpak-builder relies on flatpak, so it must be installed first.

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -1,0 +1,63 @@
+xsltproc_args = [
+  '--nonet',
+  '--stringparam', 'man.output.quietly', '1',
+  '--stringparam', 'funcsynopsis.style', 'ansi',
+  '--stringparam', 'man.th.extra1.suppress', '1',
+  '--stringparam', 'man.authors.section.enabled', '0',
+  '--stringparam', 'man.copyright.section.enabled', '0',
+]
+xsltproc = find_program('xsltproc')
+xmlto = find_program('xmlto')
+
+# TODO: is the docbook DTD/XSL catalog check needed or does xsltproc take care of that?
+configured_xml = configure_file(
+  configuration: {
+    'VERSION': meson.project_version(),
+    # FIXME: that's not a good way of this it…
+    'srcdir': meson.current_source_dir(),
+  },
+  input: 'flatpak-builder-docs.xml.in',
+  # depend_files:
+  output: 'flatpak-builder-docs.xml',
+)
+
+man_gen_command = [
+  xsltproc, xsltproc_args,
+  'http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl',
+]
+
+man_pages = [
+  ['flatpak-builder', '1'],
+  ['flatpak-manifest', '5'],
+]
+foreach man_page : man_pages
+  man_page_name = '@0@.@1@'.format(man_page[0], man_page[1])
+  custom_target(man_page[0] + '-man',
+    command: [man_gen_command, man_page_name],
+    depend_files: man_page[0] + '.xml',
+    output: man_page_name,
+    install: true,
+    install_dir: get_option('mandir') / 'man' + man_page[1],
+  )
+endforeach
+
+doc_dir = get_option('datadir') / 'doc' / meson.project_name()
+html = custom_target('docbook',
+  command: [
+    xmlto,
+    '--skip-validation',
+    'xhtml-nochunks',
+    '-o', meson.current_build_dir(),
+    '-m', files('xmlto-config.xsl'),
+    '@INPUT@',
+  ],
+  input: configured_xml,
+  output: 'flatpak-builder-docs.html',
+  install: true,
+  install_dir: doc_dir,
+)
+
+install_data(
+  files('docbook.css'),
+  install_dir: doc_dir,
+)

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -1,63 +1,65 @@
-xsltproc_args = [
-  '--nonet',
-  '--stringparam', 'man.output.quietly', '1',
-  '--stringparam', 'funcsynopsis.style', 'ansi',
-  '--stringparam', 'man.th.extra1.suppress', '1',
-  '--stringparam', 'man.authors.section.enabled', '0',
-  '--stringparam', 'man.copyright.section.enabled', '0',
-]
-xsltproc = find_program('xsltproc')
-xmlto = find_program('xmlto')
+xsltproc = find_program('xsltproc', required: get_option('docs'))
+xmlto = find_program('xmlto', required: get_option('docs'))
 
-# TODO: is the docbook DTD/XSL catalog check needed or does xsltproc take care of that?
-configured_xml = configure_file(
-  configuration: {
-    'VERSION': meson.project_version(),
-    # FIXME: that's not a good way of this it…
-    'srcdir': meson.current_source_dir(),
-  },
-  input: 'flatpak-builder-docs.xml.in',
-  # depend_files:
-  output: 'flatpak-builder-docs.xml',
-)
+if xmlto.found() and xsltproc.found()
 
-man_gen_command = [
-  xsltproc, xsltproc_args,
-  'http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl',
-]
-
-man_pages = [
-  ['flatpak-builder', '1'],
-  ['flatpak-manifest', '5'],
-]
-foreach man_page : man_pages
-  man_page_name = '@0@.@1@'.format(man_page[0], man_page[1])
-  custom_target(man_page[0] + '-man',
-    command: [man_gen_command, man_page_name],
-    depend_files: man_page[0] + '.xml',
-    output: man_page_name,
-    install: true,
-    install_dir: get_option('mandir') / 'man' + man_page[1],
+  # TODO: is the docbook DTD/XSL catalog check needed or does xsltproc take care of that?
+  configured_xml = configure_file(
+    configuration: {
+      'VERSION': meson.project_version(),
+      # FIXME: that's not a good way of this it…
+      'srcdir': meson.current_source_dir(),
+    },
+    input: 'flatpak-builder-docs.xml.in',
+    # depend_files:
+    output: 'flatpak-builder-docs.xml',
   )
-endforeach
 
-doc_dir = get_option('datadir') / 'doc' / meson.project_name()
-html = custom_target('docbook',
-  command: [
-    xmlto,
-    '--skip-validation',
-    'xhtml-nochunks',
-    '-o', meson.current_build_dir(),
-    '-m', files('xmlto-config.xsl'),
-    '@INPUT@',
-  ],
-  input: configured_xml,
-  output: 'flatpak-builder-docs.html',
-  install: true,
-  install_dir: doc_dir,
-)
+  man_pages = [
+    ['flatpak-builder', '1'],
+    ['flatpak-manifest', '5'],
+  ]
+  foreach man_page : man_pages
+    man_page_name = '@0@.@1@'.format(man_page[0], man_page[1])
+    custom_target(man_page[0] + '-man',
+      command: [
+        xsltproc,
+        '--nonet',
+        '--stringparam', 'man.output.quietly', '1',
+        '--stringparam', 'funcsynopsis.style', 'ansi',
+        '--stringparam', 'man.th.extra1.suppress', '1',
+        '--stringparam', 'man.authors.section.enabled', '0',
+        '--stringparam', 'man.copyright.section.enabled', '0',
+        '--output', '@OUTPUT@',
+        'http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl',
+        '@INPUT@'
+      ],
+      input: man_page[0] + '.xml',
+      output: man_page_name,
+      install: true,
+      install_dir: get_option('mandir') / 'man' + man_page[1],
+    )
+  endforeach
 
-install_data(
-  files('docbook.css'),
-  install_dir: doc_dir,
-)
+  doc_dir = get_option('datadir') / 'doc' / meson.project_name()
+  html = custom_target('docbook',
+    command: [
+      xmlto,
+      '--skip-validation',
+      'xhtml-nochunks',
+      '-o', meson.current_build_dir(),
+      '-m', files('xmlto-config.xsl'),
+      '@INPUT@',
+    ],
+    input: configured_xml,
+    output: 'flatpak-builder-docs.html',
+    install: true,
+    install_dir: doc_dir,
+  )
+
+  install_data(
+    files('docbook.css'),
+    install_dir: doc_dir,
+  )
+
+endif

--- a/meson.build
+++ b/meson.build
@@ -41,9 +41,7 @@ endforeach
 debugedit = find_program('debugedit')
 
 subdir('src')
-if get_option('docs')
-  subdir('doc')
-endif
+subdir('doc')
 if get_option('tests')
   subdir('tests')
 endif

--- a/meson.build
+++ b/meson.build
@@ -38,7 +38,7 @@ foreach arg : project_c_args
 endforeach
 
 # The debugedit program is a hard dependency
-debugedit = find_program('debugedit')
+debugedit = find_program('debugedit', version: '>= 5.0')
 
 subdir('src')
 subdir('doc')

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,49 @@
+project(
+  'flatpak-builder',
+  'c',
+  license: 'LGPL-2.1-or-later',
+  meson_version: '>= 0.56.2',
+  version: '1.3.1',
+  default_options: 'c_std=gnu99',
+)
+
+cc = meson.get_compiler('c')
+
+project_c_args = [
+  '-Werror=empty-body',
+  '-Werror=strict-prototypes',
+  '-Werror=missing-prototypes',
+  '-Werror=implicit-function-declaration',
+  '-Werror=format=2',
+  '-Werror=format-security',
+  '-Werror=format-nonliteral',
+  '-Werror=pointer-arith',
+  '-Werror=init-self',
+  '-Werror=missing-declarations',
+  '-Werror=return-type',
+  '-Werror=overflow',
+  '-Werror=int-conversion',
+  '-Werror=parentheses',
+  '-Werror=incompatible-pointer-types',
+  '-Werror=misleading-indentation',
+  '-Werror=missing-include-dirs',
+  # Necessary for non POSIX stuff in glibc like fallocate
+  '-D_GNU_SOURCE',
+]
+
+foreach arg : project_c_args
+  if cc.has_argument(arg)
+    add_project_arguments(arg, language: 'c')
+  endif
+endforeach
+
+# The debugedit program is a hard dependency
+debugedit = find_program('debugedit')
+
+subdir('src')
+if get_option('docs')
+  subdir('doc')
+endif
+if get_option('tests')
+  subdir('tests')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,10 @@
 option('yaml', type: 'feature', value: 'enabled', description: 'Whether to support YAML manifests')
 option('docs', type: 'feature', value: 'auto', description: 'Whether to build the DocBook documentation and man pages')
 option('tests', type: 'boolean', value: true, description: 'Whether to build and run unit tests')
-
+option(
+  'fuse',
+  type: 'combo',
+  choices: ['2', '3', 'compatible'],
+  value: 'compatible',
+  description: 'Target a specific version of FUSE for best performance or support multiple versions'
+)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,6 +1,21 @@
-option('yaml', type: 'feature', value: 'enabled', description: 'Whether to support YAML manifests')
-option('docs', type: 'feature', value: 'auto', description: 'Whether to build the DocBook documentation and man pages')
-option('tests', type: 'boolean', value: true, description: 'Whether to build and run unit tests')
+option(
+  'yaml',
+  type: 'feature',
+  value: 'enabled',
+  description: 'Whether to support YAML manifests'
+)
+option(
+  'docs',
+  type: 'feature',
+  value: 'auto',
+  description: 'Whether to build the DocBook documentation and man pages'
+)
+option(
+  'tests',
+  type: 'boolean',
+  value: true,
+  description: 'Whether to build and run unit tests'
+)
 option(
   'fuse',
   type: 'combo',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,4 @@
 option('yaml', type: 'feature', value: 'enabled', description: 'Whether to support YAML manifests')
-option('docs', type: 'boolean', value: false, description: 'Whether to build the DocBook documentation and man pages')
+option('docs', type: 'feature', value: 'auto', description: 'Whether to build the DocBook documentation and man pages')
 option('tests', type: 'boolean', value: true, description: 'Whether to build and run unit tests')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,4 @@
+option('yaml', type: 'feature', value: 'enabled', description: 'Whether to support YAML manifests')
+option('docs', type: 'boolean', value: false, description: 'Whether to build the DocBook documentation and man pages')
+option('tests', type: 'boolean', value: true, description: 'Whether to build and run unit tests')
+

--- a/src/builder-cache.c
+++ b/src/builder-cache.c
@@ -29,7 +29,7 @@
 
 #include <gio/gio.h>
 #include <ostree.h>
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "builder-flatpak-utils.h"
 #include "builder-utils.h"

--- a/src/builder-cache.h
+++ b/src/builder-cache.h
@@ -22,7 +22,7 @@
 #define __BUILDER_CACHE_H__
 
 #include <gio/gio.h>
-#include <libglnx/libglnx.h>
+#include <libglnx.h>
 
 G_BEGIN_DECLS
 

--- a/src/builder-extension.c
+++ b/src/builder-extension.c
@@ -29,7 +29,7 @@
 
 #include <glib/gi18n.h>
 #include <gio/gio.h>
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "builder-flatpak-utils.h"
 #include "builder-utils.h"

--- a/src/builder-flatpak-utils.c
+++ b/src/builder-flatpak-utils.c
@@ -38,7 +38,7 @@
 #include <sys/ioctl.h>
 
 #include <glib.h>
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 #include <gio/gunixoutputstream.h>
 #include <gio/gunixinputstream.h>
 

--- a/src/builder-flatpak-utils.h
+++ b/src/builder-flatpak-utils.h
@@ -23,7 +23,7 @@
 
 #include <string.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 #include <gio/gio.h>
 #include <gio/gunixfdlist.h>
 #include <ostree.h>

--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -27,7 +27,7 @@
 
 #include <glib/gi18n.h>
 #include <gio/gio.h>
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "builder-flatpak-utils.h"
 #include "builder-manifest.h"

--- a/src/builder-manifest.c
+++ b/src/builder-manifest.c
@@ -36,7 +36,7 @@
 
 #include <libxml/parser.h>
 
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #define LOCALES_SEPARATE_DIR "share/runtime/locale"
 

--- a/src/builder-module.c
+++ b/src/builder-module.c
@@ -29,7 +29,7 @@
 
 #include <glib/gi18n.h>
 #include <gio/gio.h>
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "builder-flatpak-utils.h"
 #include "builder-utils.h"

--- a/src/builder-post-process.c
+++ b/src/builder-post-process.c
@@ -28,7 +28,7 @@
 #include <sys/statfs.h>
 
 #include <gio/gio.h>
-#include "libglnx/libglnx.h"
+#include "libglnx.h"
 
 #include "builder-flatpak-utils.h"
 #include "builder-utils.h"

--- a/src/meson.build
+++ b/src/meson.build
@@ -31,12 +31,14 @@ config_data.set_quoted('DEBUGEDIT', debugedit.full_path())
 config_data.set_quoted('GETTEXT_PACKAGE', meson.project_name())
 config_data.set_quoted('PACKAGE_VERSION', meson.project_version())
 config_data.set_quoted('PACKAGE_STRING', '@0@-@1@'.format(meson.project_name(), meson.project_version()))
+config_data.set('GLIB_VERSION_MAX_ALLOWED', 'GLIB_VERSION_2_68')
+config_data.set('GLIB_VERSION_MIN_REQUIRED', 'GLIB_VERSION_2_66')
 config_h = configure_file(
   configuration: config_data,
   output: 'config.h',
 )
 
-glib_req = '>= 2.44'
+glib_req = '>= 2.66'
 flatpak_builder_deps = [
   dependency('glib-2.0', version: glib_req),
   dependency('gio-2.0', version: glib_req),

--- a/src/meson.build
+++ b/src/meson.build
@@ -33,6 +33,12 @@ config_data.set_quoted('PACKAGE_VERSION', meson.project_version())
 config_data.set_quoted('PACKAGE_STRING', '@0@-@1@'.format(meson.project_name(), meson.project_version()))
 config_data.set('GLIB_VERSION_MAX_ALLOWED', 'GLIB_VERSION_2_68')
 config_data.set('GLIB_VERSION_MIN_REQUIRED', 'GLIB_VERSION_2_66')
+
+# We support targeting specific fuse versions to optimize performance.
+# Currently only fuse2 has optimizations but this allows for future fuse3
+# optimizations.
+config_data.set('ASSUME_FUSE_2', get_option('fuse') == '2')
+
 config_h = configure_file(
   configuration: config_data,
   output: 'config.h',

--- a/src/meson.build
+++ b/src/meson.build
@@ -53,7 +53,6 @@ flatpak_builder_deps = [
   dependency('libcurl'),
   dependency('libelf', version: '>= 0.8.12'),
   dependency('libglnx', default_options: ['tests=false']),
-  dependency('libsoup-2.4'),
   dependency('libxml-2.0', version: '>= 2.4'),
   dependency('ostree-1', version: '>= 2017.14'),
   dependency('yaml-0.1', required: get_option('yaml')),

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,60 @@
+flatpak_builder_sources = files(
+  'builder-cache.c',
+  'builder-context.c',
+  'builder-extension.c',
+  'builder-flatpak-utils.c',
+  'builder-git.c',
+  'builder-main.c',
+  'builder-manifest.c',
+  'builder-module.c',
+  'builder-options.c',
+  'builder-post-process.c',
+  'builder-sdk-config.c',
+  'builder-source.c',
+  'builder-source-archive.c',
+  'builder-source-bzr.c',
+  'builder-source-dir.c',
+  'builder-source-extra-data.c',
+  'builder-source-file.c',
+  'builder-source-git.c',
+  'builder-source-inline.c',
+  'builder-source-patch.c',
+  'builder-source-script.c',
+  'builder-source-shell.c',
+  'builder-source-svn.c',
+  'builder-utils.c',
+)
+
+config_data = configuration_data()
+config_data.set10('FLATPAK_BUILDER_ENABLE_YAML', true)
+config_data.set_quoted('DEBUGEDIT', debugedit.full_path())
+config_data.set_quoted('GETTEXT_PACKAGE', meson.project_name())
+config_data.set_quoted('PACKAGE_VERSION', meson.project_version())
+config_data.set_quoted('PACKAGE_STRING', '@0@-@1@'.format(meson.project_name(), meson.project_version()))
+config_h = configure_file(
+  configuration: config_data,
+  output: 'config.h',
+)
+
+glib_req = '>= 2.44'
+flatpak_builder_deps = [
+  dependency('glib-2.0', version: glib_req),
+  dependency('gio-2.0', version: glib_req),
+  dependency('gio-unix-2.0', version: glib_req),
+  dependency('json-glib-1.0'),
+  dependency('libcurl'),
+  dependency('libelf', version: '>= 0.8.12'),
+  dependency('libglnx', default_options: ['tests=false']),
+  dependency('libsoup-2.4'),
+  dependency('libxml-2.0', version: '>= 2.4'),
+  dependency('ostree-1', version: '>= 2017.14'),
+  dependency('yaml-0.1', required: get_option('yaml')),
+]
+
+flatpak_builder = executable(
+  'flatpak-builder',
+  flatpak_builder_sources,
+  dependencies: flatpak_builder_deps,
+  install: true,
+)
+

--- a/subprojects/libglnx.wrap
+++ b/subprojects/libglnx.wrap
@@ -1,0 +1,6 @@
+[wrap-git]
+url = https://gitlab.gnome.org/GNOME/libglnx.git
+revision = head
+
+[provide]
+libglnx = libglnx_dep

--- a/subprojects/libyaml.wrap
+++ b/subprojects/libyaml.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = yaml-0.2.5
+source_url = https://pyyaml.org/download/libyaml/yaml-0.2.5.tar.gz
+source_filename = yaml-0.2.5.tar.gz
+source_hash = c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4
+patch_filename = libyaml_0.2.5-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/libyaml_0.2.5-1/get_patch
+patch_hash = bf2e9b922be00b6b00c5fce29d9fb8dc83f0431c77239f3b73e8b254d3f3f5b5
+
+[provide]
+yaml-0.1 = yaml_dep
+

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,5 +1,7 @@
 test_env = environment()
 test_env.set('FLATPAK_TESTS_DEBUG', '1')
+test_env.set('G_TEST_SRCDIR', meson.current_source_dir())
+test_env.set('G_TEST_BUILDDIR', meson.current_build_dir())
 test_env.prepend('PATH', meson.current_build_dir() / '..' / 'src', separator: ':')
 
 test_names = [

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -16,6 +16,7 @@ foreach test_name : test_names
   test(
     test_name,
     test_script,
+    is_parallel: false, # FIXME
     env: test_env,
     depends: flatpak_builder,
     workdir: meson.current_build_dir(),

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,21 @@
+test_env = environment()
+test_env.set('FLATPAK_TESTS_DEBUG', '1')
+test_env.prepend('PATH', meson.current_build_dir() / '..' / 'src', separator: ':')
+
+test_names = [
+  'test-builder',
+  'test-builder-deprecated',
+  'test-builder-python',
+]
+
+foreach test_name : test_names
+  test_script = find_program(test_name + '.sh')
+
+  test(
+    test_name,
+    test_script,
+    env: test_env,
+    depends: flatpak_builder,
+    workdir: meson.current_build_dir(),
+  )
+endforeach


### PR DESCRIPTION
So I started a meson port, which compiles and runs fine. But before I proceed to finish completely the port I have a few questions first.

1. Would a meson port be acceptable?
2. Should I drop the autotools buildsystem to avoid having them deviate in quality as time passes?
3. The main reason I want to port flatpak-builder to meson is because I'd like to make flatpak-builder available too as a library that GNOME Builder could use to avoid all the duplication that happens between both codebases. That *could* be done with autotools, but I really don't want nor know how to write autoconf stuff. That would allow GNOME Builder to do a more fine grained treatment on the modules and sources of a manifest, like updating modules A, B, and E but not *all* modules, as we've been willing to do in https://gitlab.gnome.org/GNOME/gnome-builder/-/merge_requests/355, without having to expand flatpak-builder's CLI for every single feature Builder would need. There wouldn't be any need for a very strict API stability since only a narrow set of projects  would actually use this library (though I don't see any reason for breaking the current API which is already very nice IMO).

If `3.` is not something acceptable then I won't finish the port since well… my interest in porting to meson is in using flatpak-builder as library in GNOME Builder.

-------

Depends on https://gitlab.gnome.org/GNOME/libglnx/-/merge_requests/23 getting fixed/merged (in the meantime deleting the content of `glnx-missing-syscall.h` makes it build alright).

There's a few FIXMEs or TODOs in the code~~but in general the biggest things left to port are tests/ and doc/.~~ Done.