### PR TITLE
Move libglnx submodule into subprojects/

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libglnx"]
-	path = libglnx
+	path = subprojects/libglnx
 	url = https://gitlab.gnome.org/GNOME/libglnx.git

--- a/Makefile.am
+++ b/Makefile.am
@@ -21,12 +21,13 @@ SUBDIRS += . doc
 endif
 
 FLATPAK_BINDIR=$(bindir)
-ACLOCAL_AMFLAGS = -I m4 -I libglnx ${ACLOCAL_FLAGS}
+ACLOCAL_AMFLAGS = -I m4 -I subprojects/libglnx ${ACLOCAL_FLAGS}
 AM_CPPFLAGS =							\
 	-DFLATPAK_BINDIR=\"$(FLATPAK_BINDIR)\"			\
 	-DFLATPAK_BASEDIR=\"$(pkgdatadir)\"			\
 	-DG_LOG_DOMAIN=\"flatpak-builder\"			\
-	-I$(srcdir)/libglnx					\
+	-I$(srcdir)/subprojects					\
+	-I$(srcdir)/subprojects/libglnx				\
 	-include "config.h"					\
 	$(NULL)
 
@@ -34,7 +35,7 @@ AM_CFLAGS = $(WARN_CFLAGS)
 
 lib_LTLIBRARIES =
 noinst_LTLIBRARIES += libglnx.la
-libglnx_srcpath := $(srcdir)/libglnx
+libglnx_srcpath := $(srcdir)/subprojects/libglnx
 libglnx_cflags := \
 	$(BASE_CFLAGS) \
 	"-I$(libglnx_srcpath)" \
@@ -42,7 +43,7 @@ libglnx_cflags := \
 	$(HIDDEN_VISIBILITY_CFLAGS) \
 	$(NULL)
 libglnx_libs := $(BASE_LIBS)
-include libglnx/Makefile-libglnx.am.inc
+include subprojects/libglnx/Makefile-libglnx.am.inc
 
 include src/Makefile.am.inc
 include tests/Makefile.am.inc

--- a/autogen.sh
+++ b/autogen.sh
@@ -18,7 +18,7 @@ fi
 # regenerated from their corresponding *.in files by ./configure anyway.
 touch INSTALL
 
-if ! test -f libglnx/README.md -a -f bubblewrap/README.md; then
+if ! test -f libglnx/README.md; then
     git submodule update --init
 fi
 # Workaround automake bug with subdir-objects and computed paths

--- a/autogen.sh
+++ b/autogen.sh
@@ -22,7 +22,9 @@ if ! test -f libglnx/README.md; then
     git submodule update --init
 fi
 # Workaround automake bug with subdir-objects and computed paths
-sed -e 's,$(libglnx_srcpath),libglnx,g' < libglnx/Makefile-libglnx.am >libglnx/Makefile-libglnx.am.inc
+sed -e 's,$(libglnx_srcpath),subprojects/libglnx,g' \
+    < subprojects/libglnx/Makefile-libglnx.am \
+    > subprojects/libglnx/Makefile-libglnx.am.inc
 
 autoreconf --force --install --verbose || exit $?
 


### PR DESCRIPTION
* autogen.sh: Remove remnants of bundled copy of bubblewrap

* Move libglnx submodule into subprojects/
    
    This is a step towards being able to build using Meson rather than
    Autotools (#382). Meson has built-in support for subprojects, but requires
    them to appear in the top-level subprojects/ directory.
    
    We have to add -Isubprojects because we include <libglnx/libglnx.h>.
