### PR TITLE
Clean up dead code in build system

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -18,7 +18,7 @@ fi
 # regenerated from their corresponding *.in files by ./configure anyway.
 touch INSTALL
 
-if ! test -f libglnx/README.md -a -f bubblewrap/README.md; then
+if ! test -f libglnx/README.md; then
     git submodule update --init
 fi
 # Workaround automake bug with subdir-objects and computed paths

--- a/configure.ac
+++ b/configure.ac
@@ -1,18 +1,5 @@
 AC_PREREQ([2.63])
 
-# Making releases:
-#   FLATPAK_MICRO_VERSION += 1;
-#   FLATPAK_INTERFACE_AGE += 1;
-#   FLATPAK_BINARY_AGE += 1;
-# if any functions have been added, set FLATPAK_INTERFACE_AGE to 0.
-# if backwards compatibility has been broken,
-# set FLATPAK_BINARY_AGE and FLATPAK_INTERFACE_AGE to 0.
-#
-# in easier to understand terms:
-#
-# on the stable branch, interface age == micro
-# on the unstable (ie master), interface age = 0
-
 m4_define([flatpak_builder_major_version], [1])
 m4_define([flatpak_builder_minor_version], [0])
 m4_define([flatpak_builder_micro_version], [12])

--- a/configure.ac
+++ b/configure.ac
@@ -92,7 +92,6 @@ AX_VALGRIND_CHECK
 PKG_PROG_PKG_CONFIG([0.24])
 
 AC_CHECK_HEADER([sys/xattr.h], [], [AC_MSG_ERROR([You must have sys/xattr.h from glibc])])
-AC_CHECK_HEADER([sys/capability.h], have_caps=yes, [AC_MSG_ERROR([sys/capability.h header not found])])
 
 PKG_CHECK_MODULES(BASE, [glib-2.0 >= $GLIB_REQS gio-2.0 gio-unix-2.0 libsoup-2.4 ostree-1 >= $OSTREE_REQS json-glib-1.0 libxml-2.0 >= 2.4 libcurl])
 

--- a/configure.ac
+++ b/configure.ac
@@ -78,6 +78,7 @@ AX_VALGRIND_CHECK
 
 PKG_PROG_PKG_CONFIG([0.24])
 
+# For libglnx
 AC_CHECK_HEADER([sys/xattr.h], [], [AC_MSG_ERROR([You must have sys/xattr.h from glibc])])
 
 PKG_CHECK_MODULES(BASE, [glib-2.0 >= $GLIB_REQS gio-2.0 gio-unix-2.0 libsoup-2.4 ostree-1 >= $OSTREE_REQS json-glib-1.0 libxml-2.0 >= 2.4 libcurl])

--- a/configure.ac
+++ b/configure.ac
@@ -91,7 +91,6 @@ AX_VALGRIND_CHECK
 
 PKG_PROG_PKG_CONFIG([0.24])
 
-AC_CHECK_FUNCS(fdwalk)
 AC_CHECK_HEADER([sys/xattr.h], [], [AC_MSG_ERROR([You must have sys/xattr.h from glibc])])
 AC_CHECK_HEADER([sys/capability.h], have_caps=yes, [AC_MSG_ERROR([sys/capability.h header not found])])
 


### PR DESCRIPTION
* autogen.sh: Remove remnants of bundled copy of bubblewrap

* build: Remove obsolete check for fdwalk
    
    Maybe Flatpak calls this, but flatpak-builder doesn't.

* build: Remove obsolete check for sys/capability.h
    
    Nothing in flatpak-builder or libglnx needs this.

* build: Remove instructions for maintaining libtool interface versioning
    
    flatpak-builder doesn't have a shared library.

* build: Comment why we check for <sys/xattr.h>