### PR TITLE
source-git: Don't bundle submodules if disabled

### DIFF
--- a/src/builder-git.c
+++ b/src/builder-git.c
@@ -409,7 +409,7 @@ git_mirror_submodules (const char     *repo_location,
           g_debug ("mirror submodule %s at revision %s\n", absolute_url, words[2]);
           if (shallow)
             {
-              if (!builder_git_shallow_mirror_ref (absolute_url, destination_path, words[2], context, error))
+              if (!builder_git_shallow_mirror_ref (absolute_url, destination_path, flags, words[2], context, error))
                 return FALSE;
             }
           else
@@ -652,6 +652,7 @@ builder_git_mirror_repo (const char     *repo_location,
 gboolean
 builder_git_shallow_mirror_ref (const char     *repo_location,
                                 const char     *destination_path,
+                                FlatpakGitMirrorFlags flags,
                                 const char     *ref,
                                 BuilderContext *context,
                                 GError        **error)
@@ -712,10 +713,13 @@ builder_git_shallow_mirror_ref (const char     *repo_location,
   if (current_commit == NULL)
     return FALSE;
 
-  if (!git_mirror_submodules (repo_location, destination_path, TRUE,
-                              FLATPAK_GIT_MIRROR_FLAGS_MIRROR_SUBMODULES | FLATPAK_GIT_MIRROR_FLAGS_DISABLE_FSCK,
-                              mirror_dir, current_commit, context, error))
-    return FALSE;
+  if (flags & FLATPAK_GIT_MIRROR_FLAGS_MIRROR_SUBMODULES)
+    {
+      if (!git_mirror_submodules (repo_location, destination_path, TRUE,
+                                  flags | FLATPAK_GIT_MIRROR_FLAGS_DISABLE_FSCK,
+                                  mirror_dir, current_commit, context, error))
+        return FALSE;
+    }
 
   return TRUE;
 }

--- a/src/builder-git.h
+++ b/src/builder-git.h
@@ -52,6 +52,7 @@ gboolean builder_git_checkout           (const char      *repo_location,
                                          GError         **error);
 gboolean builder_git_shallow_mirror_ref (const char     *repo_location,
                                          const char     *destination_path,
+                                         FlatpakGitMirrorFlags flags,
                                          const char     *ref,
                                          BuilderContext *context,
                                          GError        **error);

--- a/src/builder-source-git.c
+++ b/src/builder-source-git.c
@@ -310,7 +310,7 @@ builder_source_git_bundle (BuilderSource  *source,
 
   g_autofree char *location = NULL;
   g_autoptr(GFile) mirror_dir = NULL;
-
+  FlatpakGitMirrorFlags flags = 0;
   location = get_url_or_path (self, context, error);
 
   g_print ("builder_source_git_bundle %s\n", location);
@@ -324,8 +324,12 @@ builder_source_git_bundle (BuilderSource  *source,
   if (!flatpak_mkdir_p (mirror_dir, NULL, error))
     return FALSE;
 
+  if (!self->disable_submodules)
+    flags |= FLATPAK_GIT_MIRROR_FLAGS_MIRROR_SUBMODULES;
+
   if (!builder_git_shallow_mirror_ref (location,
                                        flatpak_file_get_path_cached (mirror_dir),
+                                       flags,
                                        self->orig_ref,
                                        context,
                                        error))


### PR DESCRIPTION
Bug was found by @lionirdeadman due to being hit with some bizarre Flathub build errors.