### PR TITLE
Validate paths

### DIFF
--- a/src/builder-context.h
+++ b/src/builder-context.h
@@ -93,6 +93,12 @@ void            builder_context_set_delete_build_dirs (BuilderContext *self,
 gboolean        builder_context_get_keep_build_dirs (BuilderContext *self);
 void            builder_context_set_sandboxed (BuilderContext *self,
                                                gboolean        sandboxed);
+gboolean        builder_context_ensure_file_sandboxed (BuilderContext *self,
+                                                       GFile          *file,
+                                                       GError        **error);
+gboolean        builder_context_ensure_parent_dir_sandboxed (BuilderContext *self,
+                                                             GFile          *file,
+                                                             GError        **error);
 gboolean        builder_context_get_sandboxed (BuilderContext *self);
 void            builder_context_set_global_cleanup (BuilderContext *self,
                                                     const char    **cleanup);

--- a/src/builder-flatpak-utils.c
+++ b/src/builder-flatpak-utils.c
@@ -691,6 +691,22 @@ flatpak_file_get_path_cached (GFile *file)
   return path;
 }
 
+gboolean
+flatpak_file_query_exists_nofollow (GFile *file)
+{
+  GFileInfo *info;
+
+  info = g_file_query_info (file, G_FILE_ATTRIBUTE_STANDARD_TYPE,
+                            G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS, FALSE, NULL);
+  if (info != NULL)
+    {
+      g_object_unref (info);
+      return TRUE;
+    }
+
+  return FALSE;
+}
+
 /* NOTE: This requires that file exists */
 GFile *
 flatpak_canonicalize_file (GFile *file, GError **error)

--- a/src/builder-flatpak-utils.c
+++ b/src/builder-flatpak-utils.c
@@ -746,6 +746,7 @@ flatpak_file_is_in (GFile *file,
 gboolean
 flatpak_cp_a (GFile         *src,
               GFile         *dest,
+              GFile         *keep_in_toplevel,
               FlatpakCpFlags flags,
               GPtrArray     *skip_files,
               GCancellable  *cancellable,
@@ -779,11 +780,20 @@ flatpak_cp_a (GFile         *src,
   do
     r = mkdir (flatpak_file_get_path_cached (dest), 0755);
   while (G_UNLIKELY (r == -1 && errno == EINTR));
-  if (r == -1 &&
-      (!merge || errno != EEXIST))
+  if (r == -1)
     {
-      glnx_set_error_from_errno (error);
-      goto out;
+      if (!merge || errno != EEXIST)
+        {
+          glnx_set_error_from_errno (error);
+          goto out;
+        }
+
+      /* When merging, ensure the new dir is inside the toplevel instead of a symlink outside */
+      if (keep_in_toplevel != NULL && !flatpak_file_is_in (dest, keep_in_toplevel))
+        {
+          flatpak_fail (error, "Recursive copy outside destination bounds");
+          goto out;
+        }
     }
 
   if (!glnx_opendirat (AT_FDCWD, flatpak_file_get_path_cached (dest), TRUE,
@@ -840,7 +850,7 @@ flatpak_cp_a (GFile         *src,
         }
       else if (g_file_info_get_file_type (child_info) == G_FILE_TYPE_DIRECTORY)
         {
-          if (!flatpak_cp_a (src_child, dest_child, flags, skip_files,
+          if (!flatpak_cp_a (src_child, dest_child, keep_in_toplevel, flags, skip_files,
                              cancellable, error))
             goto out;
         }

--- a/src/builder-flatpak-utils.h
+++ b/src/builder-flatpak-utils.h
@@ -192,6 +192,7 @@ gboolean            flatpak_spawnv (GFile                *dir,
                                     const gchar * const  *argv);
 
 const char *flatpak_file_get_path_cached (GFile *file);
+gboolean flatpak_file_query_exists_nofollow (GFile *file);
 
 GFile *flatpak_build_file_va (GFile *base,
                               va_list args);

--- a/src/builder-flatpak-utils.h
+++ b/src/builder-flatpak-utils.h
@@ -202,6 +202,12 @@ gboolean flatpak_file_rename (GFile *from,
                               GCancellable  *cancellable,
                               GError       **error);
 
+GFile * flatpak_canonicalize_file (GFile *file,
+                                   GError **error);
+/* NOTE: This requires both files to exist */
+gboolean flatpak_file_is_in (GFile *file,
+                             GFile *toplevel);
+
 typedef enum {
   FLATPAK_CP_FLAGS_NONE = 0,
   FLATPAK_CP_FLAGS_MERGE = 1<<0,

--- a/src/builder-flatpak-utils.h
+++ b/src/builder-flatpak-utils.h
@@ -218,6 +218,7 @@ typedef enum {
 
 gboolean   flatpak_cp_a (GFile         *src,
                          GFile         *dest,
+                         GFile         *keep_in_toplevel,
                          FlatpakCpFlags flags,
                          GPtrArray     *skip_files,
                          GCancellable  *cancellable,

--- a/src/builder-source-archive.c
+++ b/src/builder-source-archive.c
@@ -705,6 +705,7 @@ get_type_from_prop (BuilderSourceArchive *self)
 static gboolean
 builder_source_archive_extract (BuilderSource  *source,
                                 GFile          *dest,
+                                GFile          *source_dir,
                                 BuilderOptions *build_options,
                                 BuilderContext *context,
                                 GError        **error)

--- a/src/builder-source-archive.c
+++ b/src/builder-source-archive.c
@@ -272,6 +272,19 @@ builder_source_archive_set_property (GObject      *object,
     }
 }
 
+static gboolean
+builder_source_archive_validate (BuilderSource  *source,
+                                 GError        **error)
+{
+  BuilderSourceArchive *self = BUILDER_SOURCE_ARCHIVE (source);
+
+  if (self->dest_filename != NULL &&
+      strchr (self->dest_filename, '/') != NULL)
+    return flatpak_fail (error, "No slashes allowed in dest-filename");
+
+  return TRUE;
+}
+
 static SoupURI *
 get_uri (BuilderSourceArchive *self,
          GError              **error)
@@ -873,6 +886,7 @@ builder_source_archive_class_init (BuilderSourceArchiveClass *klass)
   source_class->extract = builder_source_archive_extract;
   source_class->bundle = builder_source_archive_bundle;
   source_class->checksum = builder_source_archive_checksum;
+  source_class->validate = builder_source_archive_validate;
 
   g_object_class_install_property (object_class,
                                    PROP_PATH,

--- a/src/builder-source-bzr.c
+++ b/src/builder-source-bzr.c
@@ -247,6 +247,7 @@ builder_source_bzr_download (BuilderSource  *source,
 static gboolean
 builder_source_bzr_extract (BuilderSource  *source,
                             GFile          *dest,
+                            GFile          *source_dir,
                             BuilderOptions *build_options,
                             BuilderContext *context,
                             GError        **error)

--- a/src/builder-source-dir.c
+++ b/src/builder-source-dir.c
@@ -124,7 +124,16 @@ get_source_file (BuilderSourceDir *self,
 
   if (self->path != NULL && self->path[0] != 0)
     {
-      return g_file_resolve_relative_path (base_dir, self->path);
+      g_autoptr(GFile) file = NULL;
+      file = g_file_resolve_relative_path (base_dir, self->path);
+
+      if (!builder_context_ensure_file_sandboxed (context, file, error))
+        {
+          g_prefix_error (error, "Unable to get source file '%s': ", self->path);
+          return NULL;
+        }
+
+      return g_steal_pointer (&file);
     }
 
   g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "source dir path not specified");

--- a/src/builder-source-dir.c
+++ b/src/builder-source-dir.c
@@ -205,8 +205,7 @@ builder_source_dir_extract (BuilderSource  *source,
     return FALSE;
 
   skip = builder_source_dir_get_skip (source, context);
-  g_mkdir_with_parents (flatpak_file_get_path_cached (src), 0755);
-  if (!flatpak_cp_a (src, dest,
+  if (!flatpak_cp_a (src, dest, source_dir,
                      FLATPAK_CP_FLAGS_MERGE|FLATPAK_CP_FLAGS_NO_CHOWN,
                      skip, NULL, error))
     return FALSE;
@@ -242,7 +241,7 @@ builder_source_dir_bundle (BuilderSource  *source,
 
   skip = builder_source_dir_get_skip (source, context);
   g_mkdir_with_parents (flatpak_file_get_path_cached (dest), 0755);
-  if (!flatpak_cp_a (src, dest,
+  if (!flatpak_cp_a (src, dest, NULL,
                      FLATPAK_CP_FLAGS_MERGE|FLATPAK_CP_FLAGS_NO_CHOWN,
                      skip, NULL, error))
     return FALSE;

--- a/src/builder-source-dir.c
+++ b/src/builder-source-dir.c
@@ -191,6 +191,7 @@ builder_source_dir_get_skip (BuilderSource  *source,
 static gboolean
 builder_source_dir_extract (BuilderSource  *source,
                             GFile          *dest,
+                            GFile          *source_dir,
                             BuilderOptions *build_options,
                             BuilderContext *context,
                             GError        **error)

--- a/src/builder-source-extra-data.c
+++ b/src/builder-source-extra-data.c
@@ -171,6 +171,7 @@ builder_source_extra_data_download (BuilderSource  *source,
 static gboolean
 builder_source_extra_data_extract (BuilderSource  *source,
                                    GFile          *dest,
+                                   GFile          *source_dir,
                                    BuilderOptions *build_options,
                                    BuilderContext *context,
                                    GError        **error)

--- a/src/builder-source-file.c
+++ b/src/builder-source-file.c
@@ -294,9 +294,18 @@ get_source_file (BuilderSourceFile *self,
 
   if (self->path != NULL && self->path[0] != 0)
     {
+      g_autoptr(GFile) file = NULL;
       *is_local = TRUE;
       *is_inline = FALSE;
-      return g_file_resolve_relative_path (base_dir, self->path);
+      file = g_file_resolve_relative_path (base_dir, self->path);
+
+      if (!builder_context_ensure_parent_dir_sandboxed (context, file, error))
+        {
+          g_prefix_error (error, "Unable to get source file '%s': ", self->path);
+          return NULL;
+        }
+
+      return g_steal_pointer (&file);
     }
 
   g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "source file path or url not specified");

--- a/src/builder-source-file.c
+++ b/src/builder-source-file.c
@@ -411,6 +411,7 @@ builder_source_file_download (BuilderSource  *source,
 static gboolean
 builder_source_file_extract (BuilderSource  *source,
                              GFile          *dest,
+                             GFile          *source_dir,
                              BuilderOptions *build_options,
                              BuilderContext *context,
                              GError        **error)

--- a/src/builder-source-file.c
+++ b/src/builder-source-file.c
@@ -447,7 +447,8 @@ builder_source_file_extract (BuilderSource  *source,
   /* If the destination file exists, just delete it. We can encounter errors when
    * trying to overwrite files that are not writable.
    */
-  if (g_file_query_exists (dest_file, NULL) && !g_file_delete (dest_file, NULL, error))
+  if (flatpak_file_query_exists_nofollow (dest_file) &&
+      !g_file_delete (dest_file, NULL, error))
     return FALSE;
 
   if (is_inline)

--- a/src/builder-source-file.c
+++ b/src/builder-source-file.c
@@ -187,6 +187,20 @@ builder_source_file_set_property (GObject      *object,
     }
 }
 
+static gboolean
+builder_source_file_validate (BuilderSource  *source,
+                              GError        **error)
+{
+  BuilderSourceFile *self = BUILDER_SOURCE_FILE (source);
+
+  if (self->dest_filename != NULL &&
+      strchr (self->dest_filename, '/') != NULL)
+    return flatpak_fail (error, "No slashes allowed in dest-filename");
+
+  return TRUE;
+}
+
+
 static SoupURI *
 get_uri (BuilderSourceFile *self,
          GError           **error)
@@ -588,6 +602,7 @@ builder_source_file_class_init (BuilderSourceFileClass *klass)
   source_class->bundle = builder_source_file_bundle;
   source_class->update = builder_source_file_update;
   source_class->checksum = builder_source_file_checksum;
+  source_class->validate = builder_source_file_validate;
 
   g_object_class_install_property (object_class,
                                    PROP_PATH,

--- a/src/builder-source-git.c
+++ b/src/builder-source-git.c
@@ -279,6 +279,7 @@ builder_source_git_download (BuilderSource  *source,
 static gboolean
 builder_source_git_extract (BuilderSource  *source,
                             GFile          *dest,
+                            GFile          *source_dir,
                             BuilderOptions *build_options,
                             BuilderContext *context,
                             GError        **error)

--- a/src/builder-source-patch.c
+++ b/src/builder-source-patch.c
@@ -281,6 +281,7 @@ patch (GFile      *dir,
 static gboolean
 builder_source_patch_extract (BuilderSource  *source,
                               GFile          *dest,
+                              GFile          *source_dir,
                               BuilderOptions *build_options,
                               BuilderContext *context,
                               GError        **error)

--- a/src/builder-source-script.c
+++ b/src/builder-source-script.c
@@ -139,6 +139,7 @@ builder_source_script_download (BuilderSource  *source,
 static gboolean
 builder_source_script_extract (BuilderSource  *source,
                                GFile          *dest,
+                               GFile          *source_dir,
                                BuilderOptions *build_options,
                                BuilderContext *context,
                                GError        **error)

--- a/src/builder-source-script.c
+++ b/src/builder-source-script.c
@@ -115,6 +115,19 @@ builder_source_script_set_property (GObject      *object,
 }
 
 static gboolean
+builder_source_script_validate (BuilderSource  *source,
+                                GError        **error)
+{
+  BuilderSourceScript *self = BUILDER_SOURCE_SCRIPT (source);
+
+  if (self->dest_filename != NULL &&
+      strchr (self->dest_filename, '/') != NULL)
+    return flatpak_fail (error, "No slashes allowed in dest-filename");
+
+  return TRUE;
+}
+
+static gboolean
 builder_source_script_download (BuilderSource  *source,
                                 gboolean        update_vcs,
                                 BuilderContext *context,
@@ -209,6 +222,7 @@ builder_source_script_class_init (BuilderSourceScriptClass *klass)
   source_class->extract = builder_source_script_extract;
   source_class->bundle = builder_source_script_bundle;
   source_class->checksum = builder_source_script_checksum;
+  source_class->validate = builder_source_script_validate;
 
   g_object_class_install_property (object_class,
                                    PROP_COMMANDS,

--- a/src/builder-source-shell.c
+++ b/src/builder-source-shell.c
@@ -167,6 +167,7 @@ run_script (BuilderContext *context,
 static gboolean
 builder_source_shell_extract (BuilderSource  *source,
                               GFile          *dest,
+                              GFile          *source_dir,
                               BuilderOptions *build_options,
                               BuilderContext *context,
                               GError        **error)

--- a/src/builder-source-svn.c
+++ b/src/builder-source-svn.c
@@ -284,6 +284,7 @@ builder_source_svn_download (BuilderSource  *source,
 static gboolean
 builder_source_svn_extract (BuilderSource  *source,
                             GFile          *dest,
+                            GFile          *source_dir,
                             BuilderOptions *build_options,
                             BuilderContext *context,
                             GError        **error)

--- a/src/builder-source.c
+++ b/src/builder-source.c
@@ -152,6 +152,7 @@ builder_source_real_download (BuilderSource  *self,
 static gboolean
 builder_source_real_extract (BuilderSource  *self,
                              GFile          *dest,
+                             GFile          *source_dir,
                              BuilderOptions *build_options,
                              BuilderContext *context,
                              GError        **error)
@@ -354,7 +355,7 @@ builder_source_download (BuilderSource  *self,
 
 gboolean
 builder_source_extract (BuilderSource  *self,
-                        GFile          *dest,
+                        GFile          *source_dir,
                         BuilderOptions *build_options,
                         BuilderContext *context,
                         GError        **error)
@@ -367,7 +368,7 @@ builder_source_extract (BuilderSource  *self,
 
   if (self->dest != NULL)
     {
-      real_dest = g_file_resolve_relative_path (dest, self->dest);
+      real_dest = g_file_resolve_relative_path (source_dir, self->dest);
 
       if (!g_file_query_exists (real_dest, NULL) &&
           !g_file_make_directory_with_parents (real_dest, NULL, error))
@@ -375,11 +376,10 @@ builder_source_extract (BuilderSource  *self,
     }
   else
     {
-      real_dest = g_object_ref (dest);
+      real_dest = g_object_ref (source_dir);
     }
 
-
-  return class->extract (self, real_dest, build_options, context, error);
+  return class->extract (self, real_dest, source_dir, build_options, context, error);
 }
 
 gboolean

--- a/src/builder-source.h
+++ b/src/builder-source.h
@@ -59,6 +59,7 @@ typedef struct
                         GError        **error);
   gboolean (* extract)(BuilderSource  *self,
                        GFile          *dest,
+                       GFile          *source_dir,
                        BuilderOptions *build_options,
                        BuilderContext *context,
                        GError        **error);
@@ -94,7 +95,7 @@ gboolean builder_source_download (BuilderSource  *self,
                                   BuilderContext *context,
                                   GError        **error);
 gboolean builder_source_extract (BuilderSource  *self,
-                                 GFile          *dest,
+                                 GFile          *source_dir,
                                  BuilderOptions *build_options,
                                  BuilderContext *context,
                                  GError        **error);

--- a/src/builder-source.h
+++ b/src/builder-source.h
@@ -74,6 +74,8 @@ typedef struct
   void (* finish)(BuilderSource  *self,
                   GPtrArray      *args,
                   BuilderContext *context);
+  gboolean (* validate)(BuilderSource  *self,
+                        GError        **error);
 } BuilderSourceClass;
 
 GType builder_source_get_type (void);
@@ -109,6 +111,8 @@ void     builder_source_checksum (BuilderSource  *self,
 void     builder_source_finish (BuilderSource  *self,
                                 GPtrArray      *args,
                                 BuilderContext *context);
+gboolean builder_source_validate (BuilderSource  *self,
+                                  GError        **error);
 
 gboolean builder_source_is_enabled (BuilderSource *self,
                                     BuilderContext *context);

--- a/src/builder-utils.c
+++ b/src/builder-utils.c
@@ -333,7 +333,7 @@ migrate_locale_dir (GFile      *source_dir,
           if (!flatpak_mkdir_p (locale_subdir, NULL, error))
             return FALSE;
 
-          if (!flatpak_cp_a (child, locale_subdir,
+          if (!flatpak_cp_a (child, locale_subdir, NULL,
                              FLATPAK_CP_FLAGS_MERGE | FLATPAK_CP_FLAGS_MOVE,
                              NULL, NULL, error))
             return FALSE;


### PR DESCRIPTION
Don't allow builds to create files outside the build dir, and, if sandboxed, read files outside the manifest base dir.