### PR TITLE
Add inline data source

### DIFF
--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -867,6 +867,30 @@
                 </variablelist>
             </refsect3>
             <refsect3>
+                <title>Inline data sources</title>
+                <para>
+                    This is a way to create a file with given contents.
+                </para>
+                <variablelist>
+                    <varlistentry>
+                        <term><option>type</option></term>
+                        <listitem><para>"inline"</para></listitem>
+                    </varlistentry>
+                    <varlistentry>
+                        <term><option>dest-filename</option> (string)</term>
+                        <listitem><para>Filename to use inside the source dir.</para></listitem>
+                    </varlistentry>
+                    <varlistentry>
+                        <term><option>contents</option> (string)</term>
+                        <listitem><para>Text data that will be put in the file.</para></listitem>
+                    </varlistentry>
+                    <varlistentry>
+                        <term><option>base64</option> (boolean)</term>
+                        <listitem><para>Whether content is base64-encoded.</para></listitem>
+                    </varlistentry>
+                </variablelist>
+            </refsect3>
+            <refsect3>
                 <title>Shell sources</title>
                 <para>
                     This is a way to create/modify the sources by running shell commands.

--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -28,6 +28,8 @@ flatpak_builder_SOURCES = \
 	src/builder-source-file.h \
 	src/builder-source-script.c \
 	src/builder-source-script.h \
+	src/builder-source-inline.c \
+	src/builder-source-inline.h \
 	src/builder-source-shell.c \
 	src/builder-source-shell.h \
 	src/builder-source-extra-data.c \

--- a/src/builder-source-archive.c
+++ b/src/builder-source-archive.c
@@ -280,7 +280,7 @@ builder_source_archive_validate (BuilderSource  *source,
 
   if (self->dest_filename != NULL &&
       strchr (self->dest_filename, '/') != NULL)
-    return flatpak_fail (error, "No slashes allowed in dest-filename");
+    return flatpak_fail (error, "No slashes allowed in dest-filename, use dest property for directory");
 
   return TRUE;
 }

--- a/src/builder-source-file.c
+++ b/src/builder-source-file.c
@@ -195,7 +195,7 @@ builder_source_file_validate (BuilderSource  *source,
 
   if (self->dest_filename != NULL &&
       strchr (self->dest_filename, '/') != NULL)
-    return flatpak_fail (error, "No slashes allowed in dest-filename");
+    return flatpak_fail (error, "No slashes allowed in dest-filename, use dest property for directory");
 
   return TRUE;
 }

--- a/src/builder-source-inline.c
+++ b/src/builder-source-inline.c
@@ -1,0 +1,233 @@
+#include "config.h"
+
+#include <string.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/statfs.h>
+
+#include "builder-flatpak-utils.h"
+#include "builder-utils.h"
+#include "builder-source-inline.h"
+
+struct BuilderSourceInline
+{
+  BuilderSource parent;
+
+  char         *contents;
+  gboolean      base64;
+  char         *dest_filename;
+};
+
+typedef struct
+{
+  BuilderSourceClass parent_class;
+} BuilderSourceInlineClass;
+
+G_DEFINE_TYPE (BuilderSourceInline, builder_source_inline, BUILDER_TYPE_SOURCE);
+
+enum {
+  PROP_0,
+  PROP_CONTENTS,
+  PROP_BASE64,
+  PROP_DEST_FILENAME,
+  LAST_PROP
+};
+
+static void
+builder_source_inline_finalize (GObject *object)
+{
+  BuilderSourceInline *self = (BuilderSourceInline *) object;
+
+  g_free (self->contents);
+  g_free (self->dest_filename);
+
+  G_OBJECT_CLASS (builder_source_inline_parent_class)->finalize (object);
+}
+
+static void
+builder_source_inline_get_property (GObject    *object,
+                                    guint       prop_id,
+                                    GValue     *value,
+                                    GParamSpec *pspec)
+{
+  BuilderSourceInline *self = BUILDER_SOURCE_INLINE (object);
+
+  switch (prop_id)
+    {
+    case PROP_CONTENTS:
+      g_value_set_string (value, self->contents);
+      break;
+
+    case PROP_BASE64:
+      g_value_set_boolean (value, self->base64);
+      break;
+
+    case PROP_DEST_FILENAME:
+      g_value_set_string (value, self->dest_filename);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+builder_source_inline_set_property (GObject      *object,
+                                    guint         prop_id,
+                                    const GValue *value,
+                                    GParamSpec   *pspec)
+{
+  BuilderSourceInline *self = BUILDER_SOURCE_INLINE (object);
+
+  switch (prop_id)
+    {
+    case PROP_CONTENTS:
+      g_free (self->contents);
+      self->contents = g_value_dup_string (value);
+      break;
+
+    case PROP_BASE64:
+      self->base64 = g_value_get_boolean (value);
+      break;
+
+    case PROP_DEST_FILENAME:
+      g_free (self->dest_filename);
+      self->dest_filename = g_value_dup_string (value);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static gboolean
+builder_source_inline_validate (BuilderSource  *source,
+                                GError        **error)
+{
+  BuilderSourceInline *self = BUILDER_SOURCE_INLINE (source);
+
+  if (self->dest_filename != NULL &&
+      strchr (self->dest_filename, '/') != NULL)
+    return flatpak_fail (error, "No slashes allowed in dest-filename, use dest property for directory");
+
+  return TRUE;
+}
+
+static gboolean
+builder_source_inline_download (BuilderSource  *source,
+                                gboolean        update_vcs,
+                                BuilderContext *context,
+                                GError        **error)
+{
+  return TRUE;
+}
+
+static gboolean
+builder_source_inline_extract (BuilderSource  *source,
+                               GFile          *dest,
+                               GFile          *source_dir,
+                               BuilderOptions *build_options,
+                               BuilderContext *context,
+                               GError        **error)
+{
+  BuilderSourceInline *self = BUILDER_SOURCE_INLINE (source);
+
+  g_autoptr(GFile) dest_file = NULL;
+  g_autoptr(GFileOutputStream) out = NULL;
+  gsize size = 0;
+
+  if (self->dest_filename == NULL)
+  {
+    g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED, "Property \"dest-filename\" must be set");
+    return FALSE;
+  }
+
+  dest_file = g_file_get_child (dest, self->dest_filename);
+
+  out = g_file_replace (dest_file, NULL, FALSE, G_FILE_CREATE_REPLACE_DESTINATION, NULL, error);
+
+  if (self->contents == NULL)
+    return TRUE;
+
+  if (self->base64)
+  {
+    g_autofree guchar *contents = NULL;
+    contents = g_base64_decode (self->contents, &size);
+    if (!g_output_stream_write_all (G_OUTPUT_STREAM (out), contents, size, NULL, NULL, error))
+      return FALSE;
+  }
+  else
+  {
+    size = strlen (self->contents);
+    if (!g_output_stream_write_all (G_OUTPUT_STREAM (out), self->contents, size, NULL, NULL, error))
+      return FALSE;
+  }
+
+  return TRUE;
+}
+
+static gboolean
+builder_source_inline_bundle (BuilderSource  *source,
+                              BuilderContext *context,
+                              GError        **error)
+{
+  /* no need to bundle anything here as this part
+     can be reconstructed from the manifest */
+  return TRUE;
+}
+
+static void
+builder_source_inline_checksum (BuilderSource  *source,
+                                BuilderCache   *cache,
+                                BuilderContext *context)
+{
+  BuilderSourceInline *self = BUILDER_SOURCE_INLINE (source);
+
+  builder_cache_checksum_str (cache, self->contents);
+  builder_cache_checksum_str (cache, self->dest_filename);
+}
+
+static void
+builder_source_inline_class_init (BuilderSourceInlineClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  BuilderSourceClass *source_class = BUILDER_SOURCE_CLASS (klass);
+
+  object_class->finalize = builder_source_inline_finalize;
+  object_class->get_property = builder_source_inline_get_property;
+  object_class->set_property = builder_source_inline_set_property;
+
+  source_class->download = builder_source_inline_download;
+  source_class->extract = builder_source_inline_extract;
+  source_class->bundle = builder_source_inline_bundle;
+  source_class->checksum = builder_source_inline_checksum;
+  source_class->validate = builder_source_inline_validate;
+
+  g_object_class_install_property (object_class,
+                                   PROP_CONTENTS,
+                                   g_param_spec_string ("contents",
+                                                        "",
+                                                        "",
+                                                        NULL,
+                                                        G_PARAM_READWRITE));
+  g_object_class_install_property (object_class,
+                                   PROP_BASE64,
+                                   g_param_spec_boolean ("base64",
+                                                         "",
+                                                         "",
+                                                         FALSE,
+                                                         G_PARAM_READWRITE));
+  g_object_class_install_property (object_class,
+                                   PROP_DEST_FILENAME,
+                                   g_param_spec_string ("dest-filename",
+                                                        "",
+                                                        "",
+                                                        NULL,
+                                                        G_PARAM_READWRITE));
+}
+
+static void
+builder_source_inline_init (BuilderSourceInline *self)
+{
+}

--- a/src/builder-source-inline.h
+++ b/src/builder-source-inline.h
@@ -1,0 +1,20 @@
+#ifndef __BUILDER_SOURCE_INLINE_H__
+#define __BUILDER_SOURCE_INLINE_H__
+
+#include "builder-source.h"
+
+G_BEGIN_DECLS
+
+typedef struct BuilderSourceInline BuilderSourceInline;
+
+#define BUILDER_TYPE_SOURCE_INLINE (builder_source_inline_get_type ())
+#define BUILDER_SOURCE_INLINE(obj) (G_TYPE_CHECK_INSTANCE_CAST ((obj), BUILDER_TYPE_SOURCE_INLINE, BuilderSourceInline))
+#define BUILDER_IS_SOURCE_INLINE(obj) (G_TYPE_CHECK_INSTANCE_TYPE ((obj), BUILDER_TYPE_SOURCE_INLINE))
+
+GType builder_source_inline_get_type (void);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (BuilderSourceInline, g_object_unref)
+
+G_END_DECLS
+
+#endif /* __BUILDER_SOURCE_INLINE_H__ */

--- a/src/builder-source-script.c
+++ b/src/builder-source-script.c
@@ -122,7 +122,7 @@ builder_source_script_validate (BuilderSource  *source,
 
   if (self->dest_filename != NULL &&
       strchr (self->dest_filename, '/') != NULL)
-    return flatpak_fail (error, "No slashes allowed in dest-filename");
+    return flatpak_fail (error, "No slashes allowed in dest-filename, use dest property for directory");
 
   return TRUE;
 }

--- a/src/builder-source.c
+++ b/src/builder-source.c
@@ -38,6 +38,7 @@
 #include "builder-source-file.h"
 #include "builder-source-dir.h"
 #include "builder-source-script.h"
+#include "builder-source-inline.h"
 #include "builder-source-shell.h"
 #include "builder-source-extra-data.h"
 
@@ -262,6 +263,8 @@ builder_source_to_json (BuilderSource *self)
     type = "dir";
   else if (BUILDER_IS_SOURCE_SCRIPT (self))
     type = "script";
+  else if (BUILDER_IS_SOURCE_INLINE (self))
+    type = "inline";
   else if (BUILDER_IS_SOURCE_SHELL (self))
     type = "shell";
   else if (BUILDER_IS_SOURCE_EXTRA_DATA (self))
@@ -302,6 +305,8 @@ builder_source_from_json (JsonNode *node)
     source = (BuilderSource *) json_gobject_deserialize (BUILDER_TYPE_SOURCE_DIR, node);
   else if (strcmp (type, "script") == 0)
     source = (BuilderSource *) json_gobject_deserialize (BUILDER_TYPE_SOURCE_SCRIPT, node);
+  else if (strcmp (type, "inline") == 0)
+    source = (BuilderSource *) json_gobject_deserialize (BUILDER_TYPE_SOURCE_INLINE, node);
   else if (strcmp (type, "shell") == 0)
     source = (BuilderSource *) json_gobject_deserialize (BUILDER_TYPE_SOURCE_SHELL, node);
   else if (strcmp (type, "extra-data") == 0)


### PR DESCRIPTION
In some cases the user may need to embed small files into the manifest. This is especially common practice for automatic manifest generators, namely flatpak-builder-tools. Currently, inline data can be stored as a `file` type source with `data:` URL.

This adds a specialized source type that writes given text content to a file (optionally, non-text data can be base64-encoded).
It provides an alternative to `data:` URLs, with following advantages:
- Less overhead from character escaping, thus, smaller manifest size. For yaml, overhead is reduced to none. For json, only a few special characters needs to be escaped.
- Much easier to write by hand (and read by a human), especially for yaml. For example, an embedded `.yarnrc` can be turned from this
  ```yaml
  type: file
  url: data:yarn-offline-mirror%20/run/build/vscode/flatpak-node/yarn-mirror%0A--install.offline%20true%0A--run.offline%20true%0A
  dest: main
  dest-filename: .yarnrc
  ```
  to this
  ```yaml
  type: inline
  contents: |
    yarn-offline-mirror /run/build/vscode/flatpak-node/yarn-mirror
    --install.offline true
    --run.offline true
  dest: main
  dest-filename: .yarnrc
  ```