### PR TITLE
Add 'no-resolved-manifest' option

### DIFF
--- a/src/builder-context.c
+++ b/src/builder-context.c
@@ -81,6 +81,7 @@ struct BuilderContext
   gboolean        have_rofiles;
   gboolean        run_tests;
   gboolean        no_shallow_clone;
+  gboolean        no_resolved_manifest;
 
   BuilderSdkConfig *sdk_config;
 };
@@ -1000,6 +1001,19 @@ builder_context_set_rebuild_on_sdk_change (BuilderContext *self,
                                            gboolean        rebuild_on_sdk_change)
 {
   self->rebuild_on_sdk_change = !!rebuild_on_sdk_change;
+}
+
+void
+builder_context_set_no_resolved_manifest (BuilderContext *self,
+                                          gboolean        no_resolved_manifest)
+{
+  self->no_resolved_manifest = !!no_resolved_manifest;
+}
+
+gboolean
+builder_context_get_no_resolved_manifest (BuilderContext *self)
+{
+  return self->no_resolved_manifest;
 }
 
 gboolean

--- a/src/builder-context.h
+++ b/src/builder-context.h
@@ -151,6 +151,9 @@ void            builder_context_set_run_tests (BuilderContext *self,
 void            builder_context_set_no_shallow_clone (BuilderContext *self,
                                                       gboolean        no_shallow_clone);
 gboolean        builder_context_get_no_shallow_clone (BuilderContext *self);
+void            builder_context_set_no_resolved_manifest (BuilderContext *self,
+                                                          gboolean        no_resolved_manifest);
+gboolean        builder_context_get_no_resolved_manifest (BuilderContext *self);
 char **         builder_context_extend_env_pre (BuilderContext *self,
                                                  char          **envp);
 char **         builder_context_extend_env_post (BuilderContext *self,

--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -87,6 +87,7 @@ static char *opt_installation;
 static gboolean opt_log_session_bus;
 static gboolean opt_log_system_bus;
 static gboolean opt_yes;
+static gboolean opt_no_resolved_manifest;
 
 static GOptionEntry entries[] = {
   { "verbose", 'v', 0, G_OPTION_ARG_NONE, &opt_verbose, "Print debug information during command processing", NULL },
@@ -141,6 +142,7 @@ static GOptionEntry entries[] = {
   { "state-dir", 0, 0, G_OPTION_ARG_FILENAME, &opt_state_dir, "Use this directory for state instead of .flatpak-builder", "PATH" },
   { "assumeyes", 'y', 0, G_OPTION_ARG_NONE, &opt_yes, N_("Automatically answer yes for all questions"), NULL },
   { "no-shallow-clone", 0, 0, G_OPTION_ARG_NONE, &opt_no_shallow_clone, "Don't use shallow clones when mirroring git repos", NULL },
+  { "no-resolved-manifest", 0, 0, G_OPTION_ARG_NONE, &opt_no_resolved_manifest, "Don't add /app/manifest.json to the build", NULL },
   { NULL }
 };
 
@@ -533,6 +535,7 @@ main (int    argc,
   builder_context_set_jobs (build_context, opt_jobs);
   builder_context_set_rebuild_on_sdk_change (build_context, opt_rebuild_on_sdk_change);
   builder_context_set_bundle_sources (build_context, opt_bundle_sources);
+  builder_context_set_no_resolved_manifest (build_context, opt_no_resolved_manifest);
 
   git_init_email ();
 

--- a/src/builder-manifest.c
+++ b/src/builder-manifest.c
@@ -3021,9 +3021,12 @@ builder_manifest_finish (BuilderManifest *self,
             return FALSE;
         }
 
-      if (!g_file_set_contents (flatpak_file_get_path_cached (manifest_file),
-                                json, strlen (json), error))
-        return FALSE;
+      if (!builder_context_get_no_resolved_manifest (context))
+        {
+          if (!g_file_set_contents (flatpak_file_get_path_cached (manifest_file),
+                                    json, strlen (json), error))
+            return FALSE;
+        }
 
       if (self->build_runtime)
         {


### PR DESCRIPTION
Some applications have security tokens passed by their build system. In these cases, having the resolved manifest file distributed with the sandbox is a security issue.

Add an option to not create the resolved manifest file.