### PR TITLE
Add 'secret-opts' option to manifest

### DIFF
--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -376,6 +376,10 @@
                     <listitem><para>This is a dictionary defining environment variables to be set during the build. Elements in this override the properties that set the environment, like cflags and ldflags. Keys with a null value unset the corresponding variable. </para></listitem>
                 </varlistentry>
                 <varlistentry>
+                    <term><option>secret-env</option> (array of strings)</term>
+                    <listitem><para>This is a array defining which host environment variables is transfered to build-commands or post-install environment.</para></listitem>
+                </varlistentry>
+                <varlistentry>
                     <term><option>build-args</option> (array of strings)</term>
                     <listitem><para>This is an array containing extra options to pass to flatpak build.</para></listitem>
                 </varlistentry>
@@ -490,6 +494,10 @@
                     order. String members in the array are interpreted
                     as the name of a separate json or yaml file that contains
                     sources.  See below for details.</para></listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term><option>secret-env</option> (array of strings)</term>
+                    <listitem><para>An array defining which host environment variables is transfered to build-commands or post-install environment.</para></listitem>
                 </varlistentry>
                 <varlistentry>
                     <term><option>config-opts</option> (array of strings)</term>

--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -388,6 +388,12 @@
                     <listitem><para>This is an array containing extra options to pass to configure.</para></listitem>
                 </varlistentry>
                 <varlistentry>
+                    <term><option>secret-opts</option> (array of strings)</term>
+                    <listitem><para>This is an array of options that will be passed to
+                    configure, meant to be used to pass secrets through host environment variables. Put
+                    the option with an environment variables and will be resolved beforehand. '-DSECRET_ID=$CI_SECRET'</para></listitem>
+                </varlistentry>
+                <varlistentry>
                     <term><option>make-args</option> (array of strings)</term>
                     <listitem><para>An array of extra arguments that will be passed to make</para></listitem>
                 </varlistentry>
@@ -488,6 +494,12 @@
                 <varlistentry>
                     <term><option>config-opts</option> (array of strings)</term>
                     <listitem><para>An array of options that will be passed to configure</para></listitem>
+                </varlistentry>
+                <varlistentry>
+                    <term><option>secret-opts</option> (array of strings)</term>
+                    <listitem><para>An array of options that will be passed to configure,
+                    meant to be used to pass secrets through host environment variables. Put the option
+                    with an environment variables and will be resolved beforehand. '-DSECRET_ID=$CI_SECRET'</para></listitem>
                 </varlistentry>
                 <varlistentry>
                     <term><option>make-args</option> (array of strings)</term>

--- a/src/builder-flatpak-utils.c
+++ b/src/builder-flatpak-utils.c
@@ -541,7 +541,7 @@ flatpak_spawn (GFile       *dir,
     g_ptr_array_add (args, (gchar *) arg);
   g_ptr_array_add (args, NULL);
 
-  res = flatpak_spawnv (dir, output, flags, error, (const gchar * const *) args->pdata);
+  res = flatpak_spawnv (dir, output, flags, error, (const gchar * const *) args->pdata, NULL);
 
   g_ptr_array_free (args, TRUE);
 
@@ -553,7 +553,8 @@ flatpak_spawnv (GFile                *dir,
                 char                **output,
                 GSubprocessFlags      flags,
                 GError              **error,
-                const gchar * const  *argv)
+                const gchar * const  *argv,
+                const gchar * const  *unresolved_argv)
 {
   g_autoptr(GSubprocessLauncher) launcher = NULL;
   g_autoptr(GSubprocess) subp = NULL;
@@ -578,7 +579,10 @@ flatpak_spawnv (GFile                *dir,
       g_subprocess_launcher_set_cwd (launcher, path);
     }
 
-  commandline = flatpak_quote_argv ((const char **)argv);
+  if (unresolved_argv != NULL)
+    commandline = flatpak_quote_argv ((const char **) unresolved_argv);
+  else
+    commandline = flatpak_quote_argv ((const char **) argv);
   g_debug ("Running: %s", commandline);
 
   subp = g_subprocess_launcher_spawnv (launcher, argv, error);

--- a/src/builder-flatpak-utils.h
+++ b/src/builder-flatpak-utils.h
@@ -189,7 +189,8 @@ gboolean            flatpak_spawnv (GFile                *dir,
                                     char                **output,
                                     GSubprocessFlags      flags,
                                     GError              **error,
-                                    const gchar * const  *argv);
+                                    const gchar * const  *argv,
+                                    const gchar * const  *unresolved_argv);
 
 const char *flatpak_file_get_path_cached (GFile *file);
 gboolean flatpak_file_query_exists_nofollow (GFile *file);

--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -258,7 +258,7 @@ do_export (BuilderContext *build_context,
   g_ptr_array_add (args, NULL);
 
   return flatpak_spawnv (NULL, NULL, G_SUBPROCESS_FLAGS_NONE, error,
-                         (const gchar * const *) args->pdata);
+                         (const gchar * const *) args->pdata, NULL);
 }
 
 static gboolean
@@ -297,7 +297,7 @@ do_install (BuilderContext *build_context,
   g_ptr_array_add (args, NULL);
 
   return flatpak_spawnv (NULL, NULL, G_SUBPROCESS_FLAGS_NONE, error,
-                         (const gchar * const *) args->pdata);
+                         (const gchar * const *) args->pdata, NULL);
 }
 
 static gboolean
@@ -981,7 +981,8 @@ main (int    argc,
                                           NULL,
                                           0,
                                           &error,
-                                          argv))
+                                          argv,
+                                          NULL))
             {
               g_printerr ("Error mirroring screenshots: %s\n", error->message);
               return 1;

--- a/src/builder-manifest.c
+++ b/src/builder-manifest.c
@@ -1545,7 +1545,7 @@ flatpak (GError **error,
   va_end (ap);
 
   res = builder_maybe_host_spawnv (NULL, &output, 0, error,
-                                   (const gchar * const *)ar->pdata);
+                                   (const gchar * const *)ar->pdata, NULL);
 
   if (res)
     {
@@ -1589,7 +1589,7 @@ flatpak_info (gboolean opt_user,
   g_ptr_array_add (args, g_strdup (ref));
   g_ptr_array_add (args, NULL);
 
-  res = builder_maybe_host_spawnv (NULL, &output, G_SUBPROCESS_FLAGS_STDERR_SILENCE, error, (const char * const *)args->pdata);
+  res = builder_maybe_host_spawnv (NULL, &output, G_SUBPROCESS_FLAGS_STDERR_SILENCE, error, (const char * const *)args->pdata, NULL);
 
   if (res)
     {
@@ -1768,7 +1768,7 @@ builder_manifest_init_app_dir (BuilderManifest *self,
   g_ptr_array_add (args, NULL);
 
   if (!flatpak_spawnv (NULL, NULL, G_SUBPROCESS_FLAGS_NONE, error,
-                       (const gchar * const *) args->pdata))
+                       (const gchar * const *) args->pdata, NULL))
     return FALSE;
 
   if (self->build_runtime && self->separate_locales)
@@ -2144,7 +2144,7 @@ command (GFile      *app_dir,
   g_ptr_array_add (args, g_strdup (commandline));
   g_ptr_array_add (args, NULL);
 
-  return builder_maybe_host_spawnv (NULL, NULL, 0, error, (const char * const *)args->pdata);
+  return builder_maybe_host_spawnv (NULL, NULL, 0, error, (const char * const *)args->pdata, NULL);
 }
 
 typedef gboolean (*ForeachFileFunc) (BuilderManifest *self,
@@ -2314,7 +2314,7 @@ appstream_compose (GFile   *app_dir,
   g_ptr_array_add (args, NULL);
   va_end (ap);
 
-  if (!builder_maybe_host_spawnv (NULL, NULL, 0, error, (const char * const *)args->pdata))
+  if (!builder_maybe_host_spawnv (NULL, NULL, 0, error, (const char * const *)args->pdata, NULL))
     {
       g_prefix_error (error, "ERROR: appstream-compose failed: ");
       return FALSE;
@@ -2991,7 +2991,7 @@ builder_manifest_finish (BuilderManifest *self,
       g_ptr_array_add (args, NULL);
 
       if (!flatpak_spawnv (NULL, NULL, G_SUBPROCESS_FLAGS_NONE, error,
-                           (const gchar * const *) args->pdata))
+                           (const gchar * const *) args->pdata, NULL))
         return FALSE;
 
       json = builder_manifest_serialize (self);
@@ -3241,7 +3241,7 @@ builder_manifest_create_platform_base (BuilderManifest *self,
       g_ptr_array_add (args, NULL);
 
       if (!flatpak_spawnv (NULL, NULL, G_SUBPROCESS_FLAGS_NONE, error,
-                           (const gchar * const *) args->pdata))
+                           (const gchar * const *) args->pdata, NULL))
         return FALSE;
 
       if (self->separate_locales)
@@ -3791,7 +3791,7 @@ builder_manifest_install_single_dep (const char *ref,
   g_ptr_array_add (args, g_strdup (ref));
   g_ptr_array_add (args, NULL);
 
-  if (!builder_maybe_host_spawnv (NULL, NULL, 0, error, (const char * const *)args->pdata))
+  if (!builder_maybe_host_spawnv (NULL, NULL, 0, error, (const char * const *)args->pdata, NULL))
     {
       g_autofree char *commandline = flatpak_quote_argv ((const char **)args->pdata);
       g_prefix_error (error, "running `%s`: ", commandline);
@@ -3825,7 +3825,7 @@ builder_manifest_update_single_dep (const char *ref,
   g_ptr_array_add (args, g_strdup (ref));
   g_ptr_array_add (args, NULL);
 
-  if (!builder_maybe_host_spawnv (NULL, NULL, 0, error, (const char * const *)args->pdata))
+  if (!builder_maybe_host_spawnv (NULL, NULL, 0, error, (const char * const *)args->pdata, NULL))
     {
       g_autofree char *commandline = flatpak_quote_argv ((const char **)args->pdata);
       g_prefix_error (error, "running `%s`: ", commandline);
@@ -4155,7 +4155,7 @@ builder_manifest_run (BuilderManifest *self,
 
   if (flatpak_is_in_sandbox ())
     {
-      if (builder_host_spawnv (NULL, NULL, G_SUBPROCESS_FLAGS_STDIN_INHERIT, NULL, (const gchar * const  *)args->pdata))
+      if (builder_host_spawnv (NULL, NULL, G_SUBPROCESS_FLAGS_STDIN_INHERIT, NULL, (const gchar * const  *)args->pdata, NULL))
         exit (1);
       else
         exit (0);

--- a/src/builder-options.c
+++ b/src/builder-options.c
@@ -59,6 +59,7 @@ struct BuilderOptions
   char      **build_args;
   char      **test_args;
   char      **config_opts;
+  char      **secret_opts;
   char      **make_args;
   char      **make_install_args;
   GHashTable *arch;
@@ -94,6 +95,7 @@ enum {
   PROP_BUILD_ARGS,
   PROP_TEST_ARGS,
   PROP_CONFIG_OPTS,
+  PROP_SECRET_OPTS,
   PROP_MAKE_ARGS,
   PROP_MAKE_INSTALL_ARGS,
   PROP_APPEND_PATH,
@@ -127,6 +129,7 @@ builder_options_finalize (GObject *object)
   g_strfreev (self->build_args);
   g_strfreev (self->test_args);
   g_strfreev (self->config_opts);
+  g_strfreev (self->secret_opts);
   g_strfreev (self->make_args);
   g_strfreev (self->make_install_args);
   g_hash_table_destroy (self->arch);
@@ -226,6 +229,10 @@ builder_options_get_property (GObject    *object,
 
     case PROP_CONFIG_OPTS:
       g_value_set_boxed (value, self->config_opts);
+      break;
+
+    case PROP_SECRET_OPTS:
+      g_value_set_boxed (value, self->secret_opts);
       break;
 
     case PROP_MAKE_ARGS:
@@ -367,6 +374,12 @@ builder_options_set_property (GObject      *object,
     case PROP_CONFIG_OPTS:
       tmp = self->config_opts;
       self->config_opts = g_strdupv (g_value_get_boxed (value));
+      g_strfreev (tmp);
+      break;
+
+    case PROP_SECRET_OPTS:
+      tmp = self->secret_opts;
+      self->secret_opts = g_strdupv (g_value_get_boxed (value));
       g_strfreev (tmp);
       break;
 
@@ -555,6 +568,15 @@ builder_options_class_init (BuilderOptionsClass *klass)
                                                        "",
                                                        G_TYPE_STRV,
                                                        G_PARAM_READWRITE));
+
+  g_object_class_install_property (object_class,
+                                   PROP_SECRET_OPTS,
+                                   g_param_spec_boxed ("secret-opts",
+                                                       "",
+                                                       "",
+                                                       G_TYPE_STRV,
+                                                       G_PARAM_READWRITE));
+
   g_object_class_install_property (object_class,
                                    PROP_MAKE_ARGS,
                                    g_param_spec_boxed ("make-args",
@@ -1275,6 +1297,14 @@ builder_options_get_config_opts (BuilderOptions *self,
 }
 
 char **
+builder_options_get_secret_opts (BuilderOptions *self,
+                                 BuilderContext *context,
+                                 char          **base_opts)
+{
+  return builder_options_get_strv (self, context, base_opts, G_STRUCT_OFFSET (BuilderOptions, secret_opts));
+}
+
+char **
 builder_options_get_make_args (BuilderOptions *self,
                                BuilderContext *context,
                                char          **base_args)
@@ -1312,6 +1342,7 @@ builder_options_checksum (BuilderOptions *self,
   builder_cache_checksum_strv (cache, self->build_args);
   builder_cache_checksum_compat_strv (cache, self->test_args);
   builder_cache_checksum_strv (cache, self->config_opts);
+  builder_cache_checksum_strv (cache, self->secret_opts);
   builder_cache_checksum_strv (cache, self->make_args);
   builder_cache_checksum_strv (cache, self->make_install_args);
   builder_cache_checksum_boolean (cache, self->strip);

--- a/src/builder-options.c
+++ b/src/builder-options.c
@@ -60,6 +60,7 @@ struct BuilderOptions
   char      **test_args;
   char      **config_opts;
   char      **secret_opts;
+  char      **secret_env;
   char      **make_args;
   char      **make_install_args;
   GHashTable *arch;
@@ -96,6 +97,7 @@ enum {
   PROP_TEST_ARGS,
   PROP_CONFIG_OPTS,
   PROP_SECRET_OPTS,
+  PROP_SECRET_ENV,
   PROP_MAKE_ARGS,
   PROP_MAKE_INSTALL_ARGS,
   PROP_APPEND_PATH,
@@ -130,6 +132,7 @@ builder_options_finalize (GObject *object)
   g_strfreev (self->test_args);
   g_strfreev (self->config_opts);
   g_strfreev (self->secret_opts);
+  g_strfreev (self->secret_env);
   g_strfreev (self->make_args);
   g_strfreev (self->make_install_args);
   g_hash_table_destroy (self->arch);
@@ -233,6 +236,10 @@ builder_options_get_property (GObject    *object,
 
     case PROP_SECRET_OPTS:
       g_value_set_boxed (value, self->secret_opts);
+      break;
+
+    case PROP_SECRET_ENV:
+      g_value_set_boxed (value, self->secret_env);
       break;
 
     case PROP_MAKE_ARGS:
@@ -380,6 +387,12 @@ builder_options_set_property (GObject      *object,
     case PROP_SECRET_OPTS:
       tmp = self->secret_opts;
       self->secret_opts = g_strdupv (g_value_get_boxed (value));
+      g_strfreev (tmp);
+      break;
+
+    case PROP_SECRET_ENV:
+      tmp = self->secret_env;
+      self->secret_env = g_strdupv (g_value_get_boxed (value));
       g_strfreev (tmp);
       break;
 
@@ -572,6 +585,14 @@ builder_options_class_init (BuilderOptionsClass *klass)
   g_object_class_install_property (object_class,
                                    PROP_SECRET_OPTS,
                                    g_param_spec_boxed ("secret-opts",
+                                                       "",
+                                                       "",
+                                                       G_TYPE_STRV,
+                                                       G_PARAM_READWRITE));
+
+  g_object_class_install_property (object_class,
+                                   PROP_SECRET_ENV,
+                                   g_param_spec_boxed ("secret-env",
                                                        "",
                                                        "",
                                                        G_TYPE_STRV,
@@ -1305,6 +1326,14 @@ builder_options_get_secret_opts (BuilderOptions *self,
 }
 
 char **
+builder_options_get_secret_env (BuilderOptions *self,
+                                BuilderContext *context,
+                                char          **base_opts)
+{
+  return builder_options_get_strv (self, context, base_opts, G_STRUCT_OFFSET (BuilderOptions, secret_env));
+}
+
+char **
 builder_options_get_make_args (BuilderOptions *self,
                                BuilderContext *context,
                                char          **base_args)
@@ -1343,6 +1372,7 @@ builder_options_checksum (BuilderOptions *self,
   builder_cache_checksum_compat_strv (cache, self->test_args);
   builder_cache_checksum_strv (cache, self->config_opts);
   builder_cache_checksum_strv (cache, self->secret_opts);
+  builder_cache_checksum_strv (cache, self->secret_env);
   builder_cache_checksum_strv (cache, self->make_args);
   builder_cache_checksum_strv (cache, self->make_install_args);
   builder_cache_checksum_boolean (cache, self->strip);

--- a/src/builder-options.h
+++ b/src/builder-options.h
@@ -60,6 +60,9 @@ char **     builder_options_get_test_args (BuilderOptions *self,
 char **     builder_options_get_config_opts (BuilderOptions *self,
                                              BuilderContext *context,
                                              char          **base_opts);
+char **     builder_options_get_secret_opts (BuilderOptions *self,
+                                             BuilderContext *context,
+                                             char          **base_opts);
 char **     builder_options_get_make_args (BuilderOptions *self,
                                            BuilderContext *context,
                                            char          **base_args);

--- a/src/builder-options.h
+++ b/src/builder-options.h
@@ -63,6 +63,9 @@ char **     builder_options_get_config_opts (BuilderOptions *self,
 char **     builder_options_get_secret_opts (BuilderOptions *self,
                                              BuilderContext *context,
                                              char          **base_opts);
+char **     builder_options_get_secret_env (BuilderOptions *self,
+                                            BuilderContext *context,
+                                            char          **base_opts);
 char **     builder_options_get_make_args (BuilderOptions *self,
                                            BuilderContext *context,
                                            char          **base_args);

--- a/src/builder-source-archive.c
+++ b/src/builder-source-archive.c
@@ -485,7 +485,7 @@ un7z (GFile       *dir,
   gboolean res;
   const gchar *argv[] = { "7z",  "x", sevenz_path, NULL };
 
-  res = flatpak_spawnv (dir, NULL, 0, error, argv);
+  res = flatpak_spawnv (dir, NULL, 0, error, argv, NULL);
 
   return res;
 }
@@ -501,7 +501,7 @@ unrpm (GFile   *dir,
       rpm_path, /* shell's $1 */
       NULL };
 
-  res = flatpak_spawnv (dir, NULL, 0, error, argv);
+  res = flatpak_spawnv (dir, NULL, 0, error, argv, NULL);
 
   return res;
 }

--- a/src/builder-source-patch.c
+++ b/src/builder-source-patch.c
@@ -271,7 +271,7 @@ patch (GFile      *dir,
   }
   g_ptr_array_add (args, NULL);
 
-  res = flatpak_spawnv (dir, NULL, 0, error, (const char **) args->pdata);
+  res = flatpak_spawnv (dir, NULL, 0, error, (const char **) args->pdata, NULL);
 
   g_ptr_array_free (args, TRUE);
 

--- a/src/builder-source-shell.c
+++ b/src/builder-source-shell.c
@@ -160,7 +160,7 @@ run_script (BuilderContext *context,
 
   source_dir_path_canonical_file = g_file_new_for_path (source_dir_path_canonical);
 
-  return builder_maybe_host_spawnv (source_dir_path_canonical_file, NULL, 0, error, (const char * const *)args->pdata);
+  return builder_maybe_host_spawnv (source_dir_path_canonical_file, NULL, 0, error, (const char * const *)args->pdata, NULL);
 }
 
 

--- a/src/builder-utils.c
+++ b/src/builder-utils.c
@@ -1624,7 +1624,8 @@ builder_host_spawnv (GFile                *dir,
                      char                **output,
                      GSubprocessFlags      flags,
                      GError              **error,
-                     const gchar * const  *argv)
+                     const gchar * const  *argv,
+                     const gchar * const  *unresolved_argv)
 {
   static FlatpakHostCommandFlags cmd_flags = FLATPAK_HOST_COMMAND_FLAGS_CLEAR_ENV | FLATPAK_HOST_COMMAND_FLAGS_WATCH_BUS;
   guint32 client_pid;
@@ -1658,7 +1659,10 @@ builder_host_spawnv (GFile                *dir,
       dir = cwd;
     }
 
-  commandline = flatpak_quote_argv ((const char **) argv);
+  if (unresolved_argv != NULL)
+    commandline = flatpak_quote_argv ((const char **) unresolved_argv);
+  else
+    commandline = flatpak_quote_argv ((const char **) argv);
   g_debug ("Running '%s' on host", commandline);
 
   connection = g_bus_get_sync (G_BUS_TYPE_SESSION, NULL, error);
@@ -1828,12 +1832,13 @@ builder_maybe_host_spawnv (GFile                *dir,
                            char                **output,
                            GSubprocessFlags      flags,
                            GError              **error,
-                           const gchar * const  *argv)
+                           const gchar * const  *argv,
+                           const gchar * const  *unresolved_argv)
 {
   if (flatpak_is_in_sandbox ())
-    return builder_host_spawnv (dir, output, flags, error, argv);
+    return builder_host_spawnv (dir, output, flags, error, argv, unresolved_argv);
 
-  return flatpak_spawnv (dir, output, flags, error, argv);
+  return flatpak_spawnv (dir, output, flags, error, argv, unresolved_argv);
 }
 
 /**

--- a/src/builder-utils.h
+++ b/src/builder-utils.h
@@ -81,12 +81,14 @@ gboolean builder_host_spawnv (GFile                *dir,
                               char                **output,
                               GSubprocessFlags      flags,
                               GError              **error,
-                              const gchar * const  *argv);
+                              const gchar * const  *argv,
+                              const gchar * const  *unresolved_argv);
 gboolean builder_maybe_host_spawnv (GFile                *dir,
                                     char                **output,
                                     GSubprocessFlags      flags,
                                     GError              **error,
-                                    const gchar * const  *argv);
+                                    const gchar * const  *argv,
+                                    const gchar * const  *unresolved_argv);
 
 gboolean builder_download_uri (SoupURI        *uri,
                                GFile          *dest,


### PR DESCRIPTION
Meant to replace #406 

Some applications have security tokens passed by their build system. In these cases, this option allow their use without distributing them in the bundle.

This PR add the new option `secret-opts` and `secret-env`.
The first is meant to be used with build system like cmake and meson, the last is meant to be used with 'build-command' and 'post-install'.

The builder check for `secret-opts` with a `$`+"env var name" showing which host env var shall replace it. The builder will replace them on the fly.
If the env var doesn't exist or the `$` is missing, the option will be ignored.

With this way, the bundle still contain the manifest and even show that this bundle have secrets.

It's mainly meant to be used with CI like github actions or gitlab CI/CD secret's.

This is the first time I manipulate C code with Glib function, so feedback are welcomed.
Same for the documentation, I feel I didn't done great job.

Here, I try this new option with a modified [obs-studio manifest](https://github.com/obsproject/obs-studio/blob/master/CI/flatpak/com.obsproject.Studio.json) with setting `-DCEF_ROOT_DIR` as a secret option.
```json
{
      "name": "obs",
      "buildsystem": "cmake-ninja",
      "builddir": true,
      "config-opts": [
        "-DCMAKE_BUILD_TYPE=Release",
        "-DENABLE_WAYLAND=ON",
        "-DBUILD_BROWSER=ON",
        "-DUNIX_STRUCTURE=ON",
        "-DUSE_XDG=ON",
        "-DDISABLE_ALSA=ON",
        "-DENABLE_PULSEAUDIO=ON",
        "-DWITH_RTMPS=ON"
      ],
      "secret-opts": [
      	"-DCEF_ROOT_DIR=$CEF"
      ],
      "sources": [
        {
          "type": "dir",
          "path": "../../"
        }
      ]
    }
```
And put this command before building:
```sh
export CEF=/app/cef
```
Since those secrets leak in the verbose output with the print of the used command, it now print a version of this command with unresolved arguments if there is secrets.
And so the verbose log now looks like that:
>`FB: Running: flatpak build --die-with-parent --env=FLATPAK_BUILDER_BUILDDIR=/run/build/obs --nofilesystem=host --filesystem=/home/tytan652/Programming/Flatpak/obs-studio/.flatpak-builder/build/obs-2 --bind-mount=/run/build/obs=/home/tytan652/Programming/Flatpak/obs-studio/.flatpak-builder/build/obs-2 --build-dir=/run/build/obs/_flatpak_build --bind-mount=/run/ccache=/home/tytan652/Programming/Flatpak/obs-studio/.flatpak-builder/ccache --env=SOURCE_DATE_EPOCH=1628833344 '--env=CFLAGS=-O2 -g -pipe -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection ' '--env=CXXFLAGS=-O2 -g -pipe -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection ' '--env=LDFLAGS=-L/app/lib -Wl,-z,relro,-z,now -Wl,--as-needed ' --env=CCACHE_DIR=/run/ccache/disabled --env=PATH=/app/bin:/usr/bin --env=LD_LIBRARY_PATH=/app/lib --env=PKG_CONFIG_PATH=/app/lib/pkgconfig:/app/share/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig --env=FLATPAK_BUILDER_N_JOBS=4 /home/tytan652/Programming/Flatpak/obs-studio/.flatpak-builder/rofiles/rofiles-ET7d3q cmake '-DCMAKE_INSTALL_PREFIX:PATH='\''/app'\''' -G Ninja .. -DCMAKE_BUILD_TYPE=Release -DENABLE_WAYLAND=ON -DBUILD_BROWSER=ON -DUNIX_STRUCTURE=ON -DUSE_XDG=ON -DDISABLE_ALSA=ON -DENABLE_PULSEAUDIO=ON -DWITH_RTMPS=ON '-DCEF_ROOT_DIR=$host:CEF'`
