### PR TITLE
WIP: Port to libappstream

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,7 +23,8 @@ jobs:
         libjson-glib-dev shared-mime-info desktop-file-utils libpolkit-agent-1-dev libpolkit-gobject-1-dev \
         libseccomp-dev libsoup2.4-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
         libgirepository1.0-dev libappstream-dev libdconf-dev clang socat flatpak \
-        libcurl4-gnutls-dev libflatpak-dev libyaml-dev elfutils git patch unzip
+        libcurl4-gnutls-dev libflatpak-dev libyaml-dev elfutils git patch unzip \
+        appstream
     - name: Check out flatpak
       uses: actions/checkout@v1
       with:
@@ -54,7 +55,8 @@ jobs:
         libjson-glib-dev shared-mime-info desktop-file-utils libpolkit-agent-1-dev libpolkit-gobject-1-dev \
         libseccomp-dev libsoup2.4-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
         libgirepository1.0-dev libappstream-dev libdconf-dev clang flatpak \
-        libcurl4-gnutls-dev libflatpak-dev libyaml-dev elfutils git patch unzip
+        libcurl4-gnutls-dev libflatpak-dev libyaml-dev elfutils git patch unzip \
+        appstream
     - name: Check out flatpak
       uses: actions/checkout@v1
       with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,7 +22,7 @@ jobs:
         libfuse-dev ostree libostree-dev libarchive-dev libcap-dev libattr1-dev libdw-dev libelf-dev \
         libjson-glib-dev shared-mime-info desktop-file-utils libpolkit-agent-1-dev libpolkit-gobject-1-dev \
         libseccomp-dev libsoup2.4-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
-        libgirepository1.0-dev libappstream-glib-dev libdconf-dev clang socat flatpak \
+        libgirepository1.0-dev libappstream-dev libdconf-dev clang socat flatpak \
         libcurl4-gnutls-dev libflatpak-dev libyaml-dev elfutils git patch unzip
     - name: Check out flatpak
       uses: actions/checkout@v1
@@ -53,7 +53,7 @@ jobs:
         libfuse-dev ostree libostree-dev libarchive-dev libcap-dev libattr1-dev libdw-dev libelf-dev \
         libjson-glib-dev shared-mime-info desktop-file-utils libpolkit-agent-1-dev libpolkit-gobject-1-dev \
         libseccomp-dev libsoup2.4-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
-        libgirepository1.0-dev libappstream-glib-dev libdconf-dev clang flatpak \
+        libgirepository1.0-dev libappstream-dev libdconf-dev clang flatpak \
         libcurl4-gnutls-dev libflatpak-dev libyaml-dev elfutils git patch unzip
     - name: Check out flatpak
       uses: actions/checkout@v1

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,10 +3,10 @@ name: Flatpak-builder CI
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
     branches:
-    - master
+    - main
 
 jobs:
   check:

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -8,7 +8,7 @@ dn=$(dirname $0)
 
 pkg_install sudo which attr fuse \
     libubsan libasan libtsan elfutils-libelf-devel libdwarf-devel \
-    elfutils git gettext-devel libappstream-glib-devel bison \
+    elfutils git gettext-devel libappstream-devel bison \
     libcurl-devel dconf-devel fuse-devel \
     /usr/bin/{update-mime-database,update-desktop-database,gtk-update-icon-cache}
 pkg_install_testing ostree-devel ostree libyaml-devel

--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,7 @@ AC_INIT([flatpak-builder],
 GLIB_REQS=2.44
 OSTREE_REQS=2017.14
 FLATPAK_REQS=0.99.1
+APPSTREAMCLI_REQS=0.15.0
 SYSTEM_DEBUGEDIT_REQS=5.0
 LIBDW_REQS=0.172
 
@@ -37,7 +38,22 @@ else
                       [AC_MSG_ERROR([You need at least version $FLATPAK_REQS of flatpak, your version is $FLATPAK_VERSION])])
 fi
 
+AC_CHECK_PROG([APPSTREAMCLI], [appstreamcli], [appstreamcli], [false])
+if test "x$APPSTREAMCLI" = xfalse; then
+   AC_MSG_ERROR([You need appstreamcli installed])
+   APPSTREAMCLI_VERSION=`$APPSTREAMCLI --version | sed 's,.*\ \([0-9]*\.[0-9]*\.[0-9]*\)$,\1,'`
+   AX_COMPARE_VERSION([$APPSTREAMCLI_REQS],[gt],[$APPSTREAMCLI_VERSION],
+                      [AC_MSG_ERROR([You need at least version $APPSTREAMCLI_REQS of appstreamcli, your version is $APPSTREAMCLI_VERSION])])
+fi
 
+AC_MSG_CHECKING([whether appstreamcli has compose support])
+AS_IF([appstreamcli compose --help >/dev/null 2>/dev/null],
+      [AC_MSG_RESULT(yes)],
+      [
+       AC_MSG_RESULT(no)
+       AC_MSG_ERROR([appstreamcli must have compose support enabled])
+      ])
+      
 LT_PREREQ([2.2.6])
 LT_INIT([disable-static])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,8 +1,8 @@
 AC_PREREQ([2.63])
 
 m4_define([flatpak_builder_major_version], [1])
-m4_define([flatpak_builder_minor_version], [2])
-m4_define([flatpak_builder_micro_version], [2])
+m4_define([flatpak_builder_minor_version], [3])
+m4_define([flatpak_builder_micro_version], [1])
 m4_define([flatpak_builder_version],
           [flatpak_builder_major_version.flatpak_builder_minor_version.flatpak_builder_micro_version])
 

--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -168,7 +168,7 @@
                 </varlistentry>
                 <varlistentry>
                     <term><option>appstream-compose</option> (boolean)</term>
-                    <listitem><para>Run appstream-compose during cleanup phase. Defaults to true.</para></listitem>
+                    <listitem><para>Run <command>appstreamcli-compose</command> during cleanup phase. Defaults to true.</para></listitem>
                 </varlistentry>
                 <varlistentry>
                     <term><option>sdk-extensions</option> (array of strings)</term>

--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -937,18 +937,8 @@ main (int    argc,
       g_autoptr(GFile) cache = flatpak_build_file (builder_context_get_state_dir (build_context), "screenshots-cache", NULL);
       g_autoptr(GFile) screenshots = flatpak_build_file (app_dir, "screenshots", NULL);
       g_autoptr(GFile) screenshots_sub = flatpak_build_file (screenshots, screenshot_subdir, NULL);
-      g_autofree char *fs_app_dir = g_strdup_printf ("--filesystem=%s", flatpak_file_get_path_cached (app_dir));
-      g_autofree char *fs_cache = g_strdup_printf ("--filesystem=%s", flatpak_file_get_path_cached (cache));
       const char *argv[] = {
-        "flatpak",
-        "build",
-        "--die-with-parent",
-        "--nofilesystem=host:reset",
-        fs_app_dir,
-        fs_cache,
-        "--share=network",
-        flatpak_file_get_path_cached (app_dir),
-        "appstreamcli-compose",
+        "appstreamcli", "compose",
         "--media-baseurl", url,
         "--media-dir", flatpak_file_get_path_cached (screenshots_sub),
         flatpak_file_get_path_cached (xml),
@@ -976,12 +966,12 @@ main (int    argc,
               g_printerr ("Error mirroring screenshots: %s\n", error->message);
               return 1;
             }
-          if (!builder_maybe_host_spawnv (NULL,
-                                          NULL,
-                                          0,
-                                          &error,
-                                          argv,
-                                          NULL))
+          if (!flatpak_spawnv (NULL,
+                               NULL,
+                               0,
+                               &error,
+                               argv,
+                               NULL))
             {
               g_printerr ("Error mirroring screenshots: %s\n", error->message);
               return 1;

--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -948,12 +948,10 @@ main (int    argc,
         fs_cache,
         "--share=network",
         flatpak_file_get_path_cached (app_dir),
-        "appstream-util",
-        "mirror-screenshots",
+        "appstreamcli-compose",
+        "--media-baseurl", url,
+        "--media-dir", flatpak_file_get_path_cached (screenshots_sub),
         flatpak_file_get_path_cached (xml),
-        url,
-        flatpak_file_get_path_cached (cache),
-        flatpak_file_get_path_cached (screenshots_sub),
         NULL
       };
 

--- a/src/builder-manifest.c
+++ b/src/builder-manifest.c
@@ -2403,16 +2403,16 @@ static GFile *
 builder_manifest_find_appdata_file (BuilderManifest *self,
                                     GFile           *app_root)
 {
-  /* We order these so that share/appdata/XXX.appdata.xml if found
+  /* We order these so that share/metainfo/$FLATPAK_ID.metainfo.xml is found
      first, as this is the target name, and apps may have both, which will
      cause issues with the rename. */
   const char *extensions[] = {
-    ".appdata.xml",
     ".metainfo.xml",
+    ".appdata.xml",
   };
   const char *dirs[] = {
-    "share/appdata",
     "share/metainfo",
+    "share/appdata",
   };
   g_autoptr(GFile) source = NULL;
 
@@ -2511,16 +2511,15 @@ builder_manifest_cleanup (BuilderManifest *self,
       appdata_source = builder_manifest_find_appdata_file (self, app_root);
       if (appdata_source)
         {
-          /* We always use the old name / dir, in case the runtime has older appdata tools */
-          g_autoptr(GFile) appdata_dir = g_file_resolve_relative_path (app_root, "share/appdata");
-          g_autofree char *appdata_basename = g_strdup_printf ("%s.appdata.xml", self->id);
+          g_autoptr(GFile) appdata_dir = g_file_resolve_relative_path (app_root, "share/metainfo");
+          g_autofree char *appdata_basename = g_strdup_printf ("%s.metainfo.xml", self->id);
 
           appdata_file = g_file_get_child (appdata_dir, appdata_basename);
 
           if (!g_file_equal (appdata_source, appdata_file))
             {
               g_autofree char *src_basename = g_file_get_basename (appdata_source);
-              g_print ("Renaming %s to share/appdata/%s\n", src_basename, appdata_basename);
+              g_print ("Renaming %s to share/metainfo/%s\n", src_basename, appdata_basename);
 
               if (!flatpak_mkdir_p (appdata_dir, NULL, error))
                 return FALSE;

--- a/src/builder-manifest.c
+++ b/src/builder-manifest.c
@@ -2292,9 +2292,9 @@ cmpstringp (const void *p1, const void *p2)
 }
 
 static gboolean
-appstream_compose (GFile   *app_dir,
-                   GError **error,
-                   ...)
+appstreamcli_compose (GFile   *app_dir,
+                      GError **error,
+                      ...)
 {
   g_autoptr(GPtrArray) args = NULL;
   const gchar *arg;
@@ -2306,7 +2306,7 @@ appstream_compose (GFile   *app_dir,
   g_ptr_array_add (args, g_strdup ("--die-with-parent"));
   g_ptr_array_add (args, g_strdup ("--nofilesystem=host:reset"));
   g_ptr_array_add (args, g_file_get_path (app_dir));
-  g_ptr_array_add (args, g_strdup ("appstream-compose"));
+  g_ptr_array_add (args, g_strdup ("appstreamcli-compose"));
 
   va_start (ap, error);
   while ((arg = va_arg (ap, const gchar *)))
@@ -2316,7 +2316,7 @@ appstream_compose (GFile   *app_dir,
 
   if (!builder_maybe_host_spawnv (NULL, NULL, 0, error, (const char * const *)args->pdata, NULL))
     {
-      g_prefix_error (error, "ERROR: appstream-compose failed: ");
+      g_prefix_error (error, "ERROR: appstreamcli-compose failed: ");
       return FALSE;
     }
 
@@ -2751,14 +2751,18 @@ builder_manifest_cleanup (BuilderManifest *self,
 
       if (self->appstream_compose && appdata_file != NULL)
         {
+          g_autofree char *app_root_path = g_file_get_path (app_root);
+          g_autofree char *prefix_arg = g_strdup_printf ("--prefix=%s", app_root_path);
           g_autofree char *basename_arg = g_strdup_printf ("--basename=%s", self->id);
-          g_print ("Running appstream-compose\n");
-          if (!appstream_compose (app_dir, error,
-                                  self->build_runtime ?  "--prefix=/usr" : "--prefix=/app",
-                                  "--origin=flatpak",
-                                  basename_arg,
-                                  self->id,
-                                  NULL))
+          g_autofree char *components_arg = g_strdup_printf ("--components=%s", self->id);
+          g_print ("Running appstreamcli-compose\n");
+          if (!appstreamcli_compose (app_dir, error,
+                                     self->build_runtime ?  "--prefix=/usr" : "--prefix=/app",
+                                     "--origin=flatpak",
+                                     "--result-root=/",
+                                     components_arg,
+                                     "/",
+                                     NULL))
             return FALSE;
         }
 


### PR DESCRIPTION
appstream-glib is mostly unmaintained, and appstream is more
actively developed (and up to date with the AppStream specification).

This ports flatpak-builder to use the command line tools from appstream
(`appstreamcli` and `appstreamcli-compose`) rather than the ones from
appstream-glib (`appstream-util`, `appstream-builder` and
`appstream-compose`).

This should result in no changes for most things, but should fix
propagation of `<requires>`/`<recommends>` elements, screenshot
`<caption>`s, and other elements which have been added to the AppStream
specification recently.

For example, see https://github.com/flathub/flathub/issues/2439

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>