### PR TITLE
source-archive: Add .tar.zst support

### DIFF
--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -675,7 +675,7 @@
                         <term><option>archive-type</option> (string)</term>
                         <listitem><para>
                             The type of archive if it cannot be guessed from the path. Possible values are "rpm", "tar",
-                            "tar-gzip", "tar-compress", "tar-bzip2", "tar-lzip", "tar-lzma", "tar-lzop", "tar-xz", "zip" and "7z".
+                            "tar-gzip", "tar-compress", "tar-bzip2", "tar-lzip", "tar-lzma", "tar-lzop", "tar-xz", "tar-zst", "zip" and "7z".
                         </para></listitem>
                     </varlistentry>
                     <varlistentry>

--- a/src/builder-source-archive.c
+++ b/src/builder-source-archive.c
@@ -83,6 +83,7 @@ typedef enum {
   TAR_LZMA,
   TAR_LZOP,
   TAR_XZ,
+  TAR_ZST,
   ZIP,
   SEVENZ,
 } BuilderArchiveType;
@@ -90,7 +91,7 @@ typedef enum {
 static gboolean
 is_tar (BuilderArchiveType type)
 {
-  return (type >= TAR) && (type <= TAR_XZ);
+  return (type >= TAR) && (type <= TAR_ZST);
 }
 
 static const char *
@@ -122,6 +123,9 @@ tar_decompress_flag (BuilderArchiveType type)
 
     case TAR_XZ:
       return "-J";
+
+    case TAR_ZST:
+      return "--zstd";
     }
 }
 
@@ -547,6 +551,10 @@ get_type (GFile *archivefile)
       g_str_has_suffix (lower, ".txz"))
     return TAR_XZ;
 
+  if (g_str_has_suffix (lower, ".tar.zst") ||
+      g_str_has_suffix (lower, ".tzst"))
+    return TAR_ZST;
+
   if (g_str_has_suffix (lower, ".zip"))
     return ZIP;
 
@@ -683,6 +691,7 @@ get_type_from_prop (BuilderSourceArchive *self)
       { "tar-lzip", TAR_LZIP },
       { "tar-lzma", TAR_LZMA },
       { "tar-xz", TAR_XZ },
+      { "tar-zst", TAR_ZST },
       { "zip", ZIP },
       { "7z", SEVENZ },
   };


### PR DESCRIPTION
Zstandard compression is becoming more widespread, so we should support it, both explicitly set via `arcgive-type` and guessed from the source file extension.