### PR TITLE
Switch to GitHub forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.yml
+++ b/.github/ISSUE_TEMPLATE/bug_template.yml
@@ -1,0 +1,55 @@
+name: Bug Report
+description: Report a bug in flatpak-builder
+title: "[Bug]: "
+labels: "bug"
+body:
+- type: checkboxes
+  attributes:
+    label: Checklist
+    description: Please make sure you have read the following.
+    options:
+      - label: I agree to follow the [Code of Conduct](https://github.com/flatpak/flatpak/blob/master/CODE_OF_CONDUCT.md) that this project adheres to.
+        required: true
+      - label: I have searched the [issue tracker](https://www.github.com/flatpak/flatpak-builder/issues) for a bug that matches the one I want to file, without success.
+        required: true
+- type: input
+  attributes:
+    label: flatpak-builder version
+    description: What version of flatpak-builder are you using? If unsure, run `flatpak-builder --version` in the terminal.
+    placeholder: 1.2.0
+  validations:
+    required: true
+- type: input
+  attributes:
+    label: Flatpak version
+    description: What version of Flatpak are you using? If unsure, run `flatpak --version` in the terminal.
+    placeholder: 1.10.2
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: How to reproduce
+    description: A clear description of how to reproduce the problem.
+    placeholder: |
+      1. Go to `...`
+      2. Click on `...`
+      3. Scroll down to `...`
+      4. See error
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Expected Behavior
+    description: A clear and concise description of what you expected to happen.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Actual Behavior
+    description: A clear description of what actually happens.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Additional Information
+    description: If your problem needs further explanation, or if the issue you're seeing cannot be reproduced in a gist, please add more information here.

--- a/.github/ISSUE_TEMPLATE/feature_template.yml
+++ b/.github/ISSUE_TEMPLATE/feature_template.yml
@@ -1,0 +1,20 @@
+name: Feature request
+description: Request a feature
+title: "[Feature request]: "
+labels: "enhancement"
+body:
+- type: checkboxes
+  attributes:
+    label: Checklist
+    description: Please make sure you have read the following.
+    options:
+      - label: I agree to follow the [Code of Conduct](https://github.com/flatpak/flatpak/blob/master/CODE_OF_CONDUCT.md) that this project adheres to.
+        required: true
+      - label: I have searched the [issue tracker](https://www.github.com/flatpak/flatpak-builder/issues) for a feature request that matches the one I want to file, without success.
+        required: true
+- type: textarea
+  attributes:
+    label: Suggestion
+    description: A clear and concise description of what you would like to see in the upcoming releases. Afterwards, describe the specific use case(s) that would be helped by this enhancement.
+  validations:
+    required: true

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,5 +1,0 @@
-## Linux distribution and version
-## Flatpak-builder version
-## Flatpak version
-## Description of the problem
-## Steps to reproduce


### PR DESCRIPTION
This MR switches to GitHub forms to improve user experience when opening an issue.
It includes a bug template and a feature request template.

Closes https://github.com/flatpak/flatpak-builder/issues/426.