### PR TITLE
Fix casing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.yml
+++ b/.github/ISSUE_TEMPLATE/bug_template.yml
@@ -1,4 +1,4 @@
-name: Bug Report
+name: Bug report
 description: Report a bug in flatpak-builder
 title: "[Bug]: "
 labels: "bug"


### PR DESCRIPTION
Sorry for the second MR, I just noticed that it's inconsistent:

![image](https://user-images.githubusercontent.com/50847364/137570815-0ccd8727-ee19-4a8e-9f54-5e98918e4023.png)

In the meantime I just made the R lower case, but if you prefer upper case, then I'll change this one back to how it was and make the R in "Feature request" capital.