### PR TITLE
source-archive: Fix get_type on 7zip archive

### DIFF
--- a/src/builder-source-archive.c
+++ b/src/builder-source-archive.c
@@ -561,6 +561,9 @@ get_type (GFile *archivefile)
   if (g_str_has_suffix (lower, ".rpm"))
     return RPM;
 
+  if (g_str_has_suffix (lower, ".7z"))
+    return SEVENZ;
+
   return UNKNOWN;
 }
 


### PR DESCRIPTION
This fix for not needing to manually set `archive-type: 7z` on 7zip archive souce.  

related: https://github.com/flatpak/flatpak-builder/pull/323