### PR TITLE
context: Make FUSE 2 optimizations opt-in

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -197,6 +197,15 @@ AM_CONDITIONAL(DOCBOOK_DOCS_ENABLED, test x$enable_docbook_docs = xyes)
 AC_ARG_VAR([XMLTO],[Define/override the 'xmlto' location.])
 AC_ARG_VAR([XMLTO_FLAGS],[Define/override 'xmlto' options, like '--skip-validation'.])
 
+AC_ARG_WITH([fuse],
+            [AS_HELP_STRING([--with-fuse={2,3}],
+                            [Only support this major version of FUSE])],
+            [fuse_major="$withval"],
+            [fuse_major=maximize-compatibility])
+AS_IF([test $fuse_major = 2],
+      [AC_DEFINE([ASSUME_FUSE_2], [],
+                 [Define to speed up FUSE 2 at the cost of FUSE 3 compatibility])])
+
 GLIB_TESTS
 
 FLATPAK_BUILDER_VERSION=flatpak_builder_version

--- a/src/builder-context.c
+++ b/src/builder-context.c
@@ -828,7 +828,15 @@ builder_context_enable_rofiles (BuilderContext *self,
   g_autofree char *tmpdir_name = NULL;
   char *argv[] = { "rofiles-fuse",
                    "-o",
-                   "kernel_cache,entry_timeout=60,attr_timeout=60,splice_write,splice_move",
+                   (
+                    "kernel_cache,entry_timeout=60,attr_timeout=60"
+#ifdef ASSUME_FUSE_2
+                    /* These options are not valid with FUSE 3, only
+                     * with FUSE 2, where they give a performance
+                     * improvement. */
+                    ",splice_write,splice_move"
+#endif
+                   ),
                    (char *)flatpak_file_get_path_cached (self->app_dir),
                    NULL,
                    NULL };


### PR DESCRIPTION
FUSE 3 does not support the splice_write,splice_move options: those
and similar speedups are enabled by default with FUSE 3.

Distributions wanting faster FUSE 2 filesystems can enable this by
configuring --with-fuse=2, but their binaries will not work when
libostree has been recompiled against FUSE 3. This behaviour was
unconditional in older releases such as 1.2.1.

Conversely, we can add opt-in features that require FUSE 3 by
configuring --with-fuse=3 if we want to, although at the moment no such
features exist.

The new default is to be compatible with all libostree versions,
regardless of whether they were compiled for FUSE 2 or 3.

Resolves: https://github.com/flatpak/flatpak-builder/issues/448