### PR TITLE
ask for default branch name instead of harcoding 'master'

### DIFF
--- a/src/builder-git.h
+++ b/src/builder-git.h
@@ -56,6 +56,7 @@ gboolean builder_git_shallow_mirror_ref (const char     *repo_location,
                                          const char     *ref,
                                          BuilderContext *context,
                                          GError        **error);
+char *   builder_git_get_default_branch (const char *repo_location);
 
 G_END_DECLS
 

--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -589,7 +589,8 @@ main (int    argc,
   if (opt_from_git)
     {
       g_autofree char *manifest_dirname = g_path_get_dirname (manifest_rel_path);
-      const char *git_branch = opt_from_git_branch ? opt_from_git_branch : "master";
+      g_autofree char *default_branch_name = builder_git_get_default_branch (opt_from_git);
+      const char *git_branch = opt_from_git_branch ? opt_from_git_branch : default_branch_name;
       g_autoptr(GFile) build_subdir = NULL;
 
       build_subdir = builder_context_allocate_build_subdir (build_context, manifest_basename, &error);

--- a/src/builder-source-git.c
+++ b/src/builder-source-git.c
@@ -44,6 +44,7 @@ struct BuilderSourceGit
   char         *tag;
   char         *commit;
   char         *orig_ref;
+  char         *default_branch_name;
   gboolean      disable_fsckobjects;
   gboolean      disable_shallow_clone;
   gboolean      disable_submodules;
@@ -80,6 +81,7 @@ builder_source_git_finalize (GObject *object)
   g_free (self->tag);
   g_free (self->commit);
   g_free (self->orig_ref);
+  g_free (self->default_branch_name);
 
   G_OBJECT_CLASS (builder_source_git_parent_class)->finalize (object);
 }
@@ -184,7 +186,8 @@ builder_source_git_set_property (GObject      *object,
 }
 
 static const char *
-get_branch (BuilderSourceGit *self)
+get_branch (BuilderSourceGit *self,
+            const char       *repo_location)
 {
   if (self->branch)
     return self->branch;
@@ -193,7 +196,12 @@ get_branch (BuilderSourceGit *self)
   else if (self->commit)
     return self->commit;
   else
-    return "master";
+    {
+      if (self->default_branch_name == NULL)
+        self->default_branch_name = builder_git_get_default_branch (repo_location);
+
+      return self->default_branch_name;
+    }
 }
 
 static char *
@@ -257,7 +265,7 @@ builder_source_git_download (BuilderSource  *source,
     flags |= FLATPAK_GIT_MIRROR_FLAGS_WILL_FETCH_FROM;
 
   if (!builder_git_mirror_repo (location, NULL, flags,
-                                get_branch (self),
+                                get_branch (self, location),
                                 context,
                                 error))
     return FALSE;
@@ -265,8 +273,8 @@ builder_source_git_download (BuilderSource  *source,
   if (self->commit != NULL && (self->branch != NULL || self->tag != NULL))
     {
       /* We want to support the commit being both a tag object and the real commit object that it points too */
-      g_autofree char *current_commit = builder_git_get_current_commit (location, get_branch (self), FALSE, context, error);
-      g_autofree char *current_commit2 = builder_git_get_current_commit (location, get_branch (self), TRUE, context, error);
+      g_autofree char *current_commit = builder_git_get_current_commit (location, get_branch (self, location), FALSE, context, error);
+      g_autofree char *current_commit2 = builder_git_get_current_commit (location, get_branch (self, location), TRUE, context, error);
       if (current_commit == NULL || current_commit2 == NULL)
         return FALSE;
       if (strcmp (current_commit, self->commit) != 0 && strcmp (current_commit2, self->commit) != 0)
@@ -295,7 +303,7 @@ builder_source_git_extract (BuilderSource  *source,
   if (!self->disable_submodules)
     mirror_flags |= FLATPAK_GIT_MIRROR_FLAGS_MIRROR_SUBMODULES;
 
-  if (!builder_git_checkout (location, get_branch (self),
+  if (!builder_git_checkout (location, get_branch (self, location),
                              dest, context, mirror_flags, error))
     return FALSE;
 
@@ -360,7 +368,7 @@ builder_source_git_checksum (BuilderSource  *source,
   location = get_url_or_path (self, context, &error);
   if (location != NULL)
     {
-      current_commit = builder_git_get_current_commit (location,get_branch (self), FALSE, context, &error);
+      current_commit = builder_git_get_current_commit (location, get_branch (self, location), FALSE, context, &error);
       if (current_commit)
         builder_cache_checksum_str (cache, current_commit);
       else if (error)
@@ -385,7 +393,7 @@ builder_source_git_update (BuilderSource  *source,
   if (location == NULL)
     return FALSE;
 
-  self->orig_ref = g_strdup (get_branch (self));
+  self->orig_ref = g_strdup (get_branch (self, location));
   current_commit = builder_git_get_current_commit (location, self->orig_ref, FALSE, context, NULL);
   if (current_commit)
     {
@@ -478,4 +486,5 @@ builder_source_git_class_init (BuilderSourceGitClass *klass)
 static void
 builder_source_git_init (BuilderSourceGit *self)
 {
+  self->default_branch_name = NULL;
 }

--- a/src/builder-source-git.c
+++ b/src/builder-source-git.c
@@ -486,5 +486,4 @@ builder_source_git_class_init (BuilderSourceGitClass *klass)
 static void
 builder_source_git_init (BuilderSourceGit *self)
 {
-  self->default_branch_name = NULL;
 }


### PR DESCRIPTION
Many projects are starting to change their default branch
name from 'master' to 'main' and similar, eg.:
https://gitlab.gnome.org/GNOME/evince/-/issues/1635

So when a project is not providing a specific branch,
instead of defaulting to 'master' we should ask the
remote repo which is their default branch name.

That can be retrieve with following command:
git ls-remote --symref origin HEAD

where 'origin' can also be a URL to the repository.

Fixes issue #375