### PR TITLE
Add option to override SOURCE_DATE_EPOCH.

### DIFF
--- a/src/builder-context.c
+++ b/src/builder-context.c
@@ -593,6 +593,12 @@ builder_context_set_default_branch (BuilderContext *self,
   self->default_branch = g_strdup (default_branch);
 }
 
+gint64
+builder_context_get_source_date_epoch (BuilderContext *self)
+{
+  return self->source_date_epoch;
+}
+
 void
 builder_context_set_source_date_epoch (BuilderContext *self,
                                        gint64 source_date_epoch)

--- a/src/builder-context.h
+++ b/src/builder-context.h
@@ -77,6 +77,7 @@ void            builder_context_set_arch (BuilderContext *self,
 const char *    builder_context_get_default_branch (BuilderContext *self);
 void            builder_context_set_default_branch (BuilderContext *self,
                                                     const char     *default_branch);
+gint64          builder_context_get_source_date_epoch (BuilderContext *self);
 void            builder_context_set_source_date_epoch (BuilderContext *self,
                                                        gint64 source_date_epoch);
 const char *    builder_context_get_stop_at (BuilderContext *self);

--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -87,6 +87,7 @@ static char *opt_installation;
 static gboolean opt_log_session_bus;
 static gboolean opt_log_system_bus;
 static gboolean opt_yes;
+static gint64 opt_source_date_epoch = -1;
 
 static GOptionEntry entries[] = {
   { "verbose", 'v', 0, G_OPTION_ARG_NONE, &opt_verbose, "Print debug information during command processing", NULL },
@@ -141,6 +142,7 @@ static GOptionEntry entries[] = {
   { "state-dir", 0, 0, G_OPTION_ARG_FILENAME, &opt_state_dir, "Use this directory for state instead of .flatpak-builder", "PATH" },
   { "assumeyes", 'y', 0, G_OPTION_ARG_NONE, &opt_yes, N_("Automatically answer yes for all questions"), NULL },
   { "no-shallow-clone", 0, 0, G_OPTION_ARG_NONE, &opt_no_shallow_clone, "Don't use shallow clones when mirroring git repos", NULL },
+  { "override-source-date-epoch", 0, 0, G_OPTION_ARG_INT64, &opt_source_date_epoch, "Use this timestamp to perform the build, instead of the last modification time of the manifest.", NULL },
   { NULL }
 };
 
@@ -646,7 +648,9 @@ main (int    argc,
       return 1;
     }
 
-  if (stat (flatpak_file_get_path_cached (manifest_file), &statbuf) == 0)
+  if (opt_source_date_epoch > -1)
+    builder_context_set_source_date_epoch (build_context, opt_source_date_epoch);
+  else if (stat (flatpak_file_get_path_cached (manifest_file), &statbuf) == 0)
     builder_context_set_source_date_epoch (build_context, (gint64)statbuf.st_mtime);
 
   manifest_sha256 = g_compute_checksum_for_string (G_CHECKSUM_SHA256, manifest_contents, -1);

--- a/src/builder-manifest.c
+++ b/src/builder-manifest.c
@@ -36,6 +36,7 @@
 
 #include <libxml/parser.h>
 
+#include "glibconfig.h"
 #include "libglnx/libglnx.h"
 
 #define LOCALES_SEPARATE_DIR "share/runtime/locale"
@@ -107,6 +108,7 @@ struct BuilderManifest
   GList          *expanded_modules;
   GList          *add_extensions;
   GList          *add_build_extensions;
+  gint64          source_date_epoch;
 };
 
 typedef struct
@@ -169,6 +171,7 @@ enum {
   PROP_ADD_BUILD_EXTENSIONS,
   PROP_EXTENSION_TAG,
   PROP_TOKEN_TYPE,
+  PROP_SOURCE_DATE_EPOCH,
   LAST_PROP
 };
 
@@ -476,6 +479,10 @@ builder_manifest_get_property (GObject    *object,
       g_value_set_int (value, (int)self->token_type);
       break;
 
+    case PROP_SOURCE_DATE_EPOCH:
+      g_value_set_int64 (value, self->source_date_epoch);
+      break;
+
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
@@ -737,6 +744,10 @@ builder_manifest_set_property (GObject      *object,
 
     case PROP_TOKEN_TYPE:
       self->token_type = (gint32)g_value_get_int (value);
+      break;
+
+    case PROP_SOURCE_DATE_EPOCH:
+      self->source_date_epoch = g_value_get_int64 (value);
       break;
 
     default:
@@ -1089,6 +1100,16 @@ builder_manifest_class_init (BuilderManifestClass *klass)
                                                      -1,
                                                      G_MAXINT32,
                                                      -1,
+                                                     G_PARAM_READWRITE));
+
+  g_object_class_install_property (object_class,
+                                   PROP_SOURCE_DATE_EPOCH,
+                                   g_param_spec_int64 ("source-date-epoch",
+                                                     "",
+                                                     "",
+                                                     0,
+                                                     G_MAXINT64,
+                                                     0,
                                                      G_PARAM_READWRITE));
 }
 
@@ -1628,6 +1649,8 @@ builder_manifest_start (BuilderManifest *self,
   g_autoptr(GHashTable) names = g_hash_table_new (g_str_hash, g_str_equal);
   g_autofree char *sdk_path = NULL;
   const char *stop_at;
+
+  self->source_date_epoch = builder_context_get_source_date_epoch(context);
 
   if (self->sdk == NULL)
     {

--- a/src/builder-manifest.c
+++ b/src/builder-manifest.c
@@ -36,7 +36,6 @@
 
 #include <libxml/parser.h>
 
-#include "glibconfig.h"
 #include "libglnx/libglnx.h"
 
 #define LOCALES_SEPARATE_DIR "share/runtime/locale"

--- a/src/builder-manifest.c
+++ b/src/builder-manifest.c
@@ -1104,12 +1104,12 @@ builder_manifest_class_init (BuilderManifestClass *klass)
   g_object_class_install_property (object_class,
                                    PROP_SOURCE_DATE_EPOCH,
                                    g_param_spec_int64 ("source-date-epoch",
-                                                      "",
-                                                      "",
-                                                      0,
-                                                      G_MAXINT64,
-                                                      0,
-                                                      G_PARAM_READWRITE));
+                                                       "",
+                                                       "",
+                                                       0,
+                                                       G_MAXINT64,
+                                                       0,
+                                                       G_PARAM_READWRITE));
 }
 
 static void

--- a/src/builder-manifest.c
+++ b/src/builder-manifest.c
@@ -1104,12 +1104,12 @@ builder_manifest_class_init (BuilderManifestClass *klass)
   g_object_class_install_property (object_class,
                                    PROP_SOURCE_DATE_EPOCH,
                                    g_param_spec_int64 ("source-date-epoch",
-                                                     "",
-                                                     "",
-                                                     0,
-                                                     G_MAXINT64,
-                                                     0,
-                                                     G_PARAM_READWRITE));
+                                                      "",
+                                                      "",
+                                                      0,
+                                                      G_MAXINT64,
+                                                      0,
+                                                      G_PARAM_READWRITE));
 }
 
 static void
@@ -1649,7 +1649,7 @@ builder_manifest_start (BuilderManifest *self,
   g_autofree char *sdk_path = NULL;
   const char *stop_at;
 
-  self->source_date_epoch = builder_context_get_source_date_epoch(context);
+  self->source_date_epoch = builder_context_get_source_date_epoch (context);
 
   if (self->sdk == NULL)
     {


### PR DESCRIPTION
`flatpak-builder` overrides `SOURCE_DATE_EPOCH` with the last modification time of the manifest file (of the program being built).
With this option, it would provide a more convenient interface to perform the same thing, useful when trying to reproduce a build.
Concretely I just added an optional parameter `--override-source-date-epoch` which, if set, will override the `SOURCE_DATE_EPOCH` with the given value. 
It's my first time looking at the code of this project, therefore, even though I made minimal changes, I might have made some mistakes.
Update:
I also added the timestamp to the resolved manifest, to actually have reproducible builds.