### PR TITLE
Add sdk-version

### DIFF
--- a/data/flatpak-manifest.schema.json
+++ b/data/flatpak-manifest.schema.json
@@ -1155,6 +1155,10 @@
       "description": "The name of the development runtime that the application builds with.",
       "type": "string"
     },
+    "sdk-version": {
+      "description": "The version of the development runtime that the application builds with, defaults to the runtime version.",
+      "type": "string"
+    },
     "var": {
       "description": "Initialize the (otherwise empty) writable /var in the build with a copy of this runtime.",
       "type": "string"

--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -121,6 +121,10 @@
                     <listitem><para>The name of the development runtime that the application builds with.</para></listitem>
                 </varlistentry>
                 <varlistentry>
+                    <term><option>sdk-version</option> (string)</term>
+                    <listitem><para>The version of the development runtime that the application builds with, defaults to the runtime version.</para></listitem>
+                </varlistentry>
+                <varlistentry>
                     <term><option>var</option> (string)</term>
                     <listitem><para>Initialize the (otherwise empty) writable /var in the build with a copy of this runtime.</para></listitem>
                 </varlistentry>


### PR DESCRIPTION
If you want to specify another SDK version than the runtime (what is needed e.g. for extensions) you currently have to use `sdk: name//version`. We already have things like `runtime-version` and `base-version`, so why not add `sdk-version`?

The code is (of course) tested and works. I hope I didn't miss anything.