### PR TITLE
Allow use file protocol when update submodule.

### DIFF
--- a/src/builder-git.c
+++ b/src/builder-git.c
@@ -814,7 +814,7 @@ git_extract_submodule (const char     *repo_location,
             return FALSE;
 
           if (!git (checkout_dir, NULL, 0, error,
-                    "submodule", "update", "--init", path, NULL))
+                    "-c", "protocol.file.allow=always", "submodule", "update", "--init", path, NULL))
             return FALSE;
 
           child_dir = g_file_resolve_relative_path (checkout_dir, path);


### PR DESCRIPTION
git 2.38.1 prevent file protocol to be used by default for security reasons. Such issue does not apply to flatpak-builder since the repos are overriden with local repo on purpose.

Fixes #495

Signed-off-by: Weng Xuetian <wengxt@gmail.com>