### PR TITLE
also disable shallow clone when retrieving manifest "from-git" with --from-git

### DIFF
--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -606,6 +606,11 @@ main (int    argc,
 
       int mirror_flags = FLATPAK_GIT_MIRROR_FLAGS_MIRROR_SUBMODULES;
 
+      if (opt_no_shallow_clone)
+        {
+          mirror_flags |= FLATPAK_GIT_MIRROR_FLAGS_DISABLE_SHALLOW;
+        }
+
       if (opt_disable_updates)
         {
           mirror_flags |= FLATPAK_GIT_MIRROR_FLAGS_UPDATE;


### PR DESCRIPTION
When doing an initial clone of a repo to get the manifest from a git repo hosted by a HTTP (or HTTPS) server, shallow clones fail with the following message:

```
Initialized empty Git repository in /home/purism/.flatpak-builder/git/https_domain.com_code_repo.git-L04WW1/
Fetching git repo https://domain.com/code/repo.git, ref refs/heads/phil/flatpak
fatal: dumb http transport does not support shallow capabilities
Can't clone manifest repo: Child process exited with code 128
```

adding the `--no-shallow-clone` doesn't change the behavior for this `--from-git=` clone. This patch fixes the behavior and makes it work as exepected for me.

fixes #501