### PR TITLE
Fix segfaults

### DIFF
--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -406,6 +406,7 @@ main (int    argc,
   int argnr;
   char *p;
   struct stat statbuf;
+  gsize manifest_length;
 
   setlocale (LC_ALL, "");
 
@@ -641,10 +642,15 @@ main (int    argc,
     }
 
   builder_context_set_base_dir (build_context, base_dir);
-
-  if (!g_file_get_contents (flatpak_file_get_path_cached (manifest_file), &manifest_contents, NULL, &error))
+  if (!g_file_get_contents (flatpak_file_get_path_cached (manifest_file), &manifest_contents, &manifest_length, &error))
     {
       g_printerr ("Can't load '%s': %s\n", manifest_rel_path, error->message);
+      return 1;
+    }
+
+  if (manifest_length == 0)
+    {
+      g_printerr ("Empty manifest file: '%s'\n", manifest_rel_path);
       return 1;
     }
 

--- a/src/builder-utils.c
+++ b/src/builder-utils.c
@@ -528,10 +528,18 @@ builder_gobject_from_data (GType       gtype,
                            GError    **error)
 {
   g_autoptr(JsonNode) json = builder_json_node_from_data (relpath, contents, error);
-  if (json != NULL)
-    return json_gobject_deserialize (gtype, json);
-  else
+
+  if (json == NULL)
     return NULL;
+
+  if (JSON_NODE_TYPE (json) != JSON_NODE_OBJECT)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "Unexpected identifier '%s'", json_to_string (json, FALSE));
+      return NULL;
+    }
+
+  return json_gobject_deserialize (gtype, json);
 }
 
 char **


### PR DESCRIPTION
This MR fixes #492, a segfault when the manifest is empty.
The second commit fixes a segfault when the manifest contains only a number or a string.

Best Regards
Manuel