### PR TITLE
Run shell before the start of the build

### DIFF
--- a/src/builder-module.c
+++ b/src/builder-module.c
@@ -1648,6 +1648,13 @@ builder_module_build_helper (BuilderModule  *self,
         }
     }
 
+  if (run_shell)
+    {
+      if (!shell (app_dir, self->name, context, source_dir, build_dir_relative, build_args, env, error))
+        return FALSE;
+      return TRUE;
+    }
+
   if (configure_file)
     has_configure = g_file_query_exists (configure_file, NULL);
 
@@ -1846,13 +1853,6 @@ builder_module_build_helper (BuilderModule  *self,
     {
       /* ninja defaults to a parallel make, disable it if requested */
       make_j = g_strdup ("-j1");
-    }
-
-  if (run_shell)
-    {
-      if (!shell (app_dir, self->name, context, source_dir, build_dir_relative, build_args, env, error))
-        return FALSE;
-      return TRUE;
     }
 
   /* Build and install */


### PR DESCRIPTION
Hi :)
For some build systems there were calls to `build` before `shell`, which made it impossible to open a shell in the build environment if the build failed. I don't think that moving `shell` before has an implication on the environment as the code in between only seems to do checks on the project.

Fixes #479