### PR TITLE
git: Just skip submodules that git ls-tree don't know about

### DIFF
--- a/src/builder-git.c
+++ b/src/builder-git.c
@@ -395,11 +395,9 @@ git_mirror_submodules (const char     *repo_location,
             return FALSE;
 
           lines = g_strsplit (g_strstrip (ls_tree), "\n", 0);
+          /* There can be path in the .gitmodules file that are not submodules. */
           if (g_strv_length (lines) != 1)
-            {
-              g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "Not a gitlink tree: %s", path);
-              return FALSE;
-            }
+            continue;
 
           words = g_strsplit_set (lines[0], " \t", 4);
 
@@ -794,11 +792,9 @@ git_extract_submodule (const char     *repo_location,
             return FALSE;
 
           lines = g_strsplit (g_strstrip (ls_tree), "\n", 0);
+          /* There can be path in the .gitmodules file that are not submodules. */
           if (g_strv_length (lines) != 1)
-            {
-              g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "Not a gitlink tree: %s", path);
-              return FALSE;
-            }
+            continue;
 
           words = g_strsplit_set (lines[0], " \t", 4);
 


### PR DESCRIPTION
I found this bug with this repository:

https://github.com/GuitarML/SmartGuitarAmp

For the resulting flatpak manifest I had to skip submodules and add the sources.

See https://github.com/hfiguiere/flathub/blob/guitarml/org.freedesktop.LinuxAudio.Plugins.GuitarML.json#L231

So basically if git ls-tree return nothing when the submodule is list in gitmodule it will just be skipped. I check with my manifest and could successfully reenable the submodules.