### PR TITLE
Fix installation of "as-installed" tests

### DIFF
--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -9,7 +9,6 @@ AM_TESTS_ENVIRONMENT += FLATPAK_BUILDER_DEBUGEDIT=$$(cd $(top_builddir) && pwd)/
 endif
 
 dist_installed_test_extra_scripts += \
-	buildutil/tap-driver.sh \
 	tests/empty-configure \
 	tests/test-configure \
 	tests/make-test-app.sh \

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -44,7 +44,9 @@ dist_installed_test_data = \
 	tests/org.test.Deprecated.MD5.file.json \
 	tests/org.test.Deprecated.MD5.file.yaml \
 	tests/org.test.Deprecated.SHA1.archive.json \
+	tests/org.test.Deprecated.SHA1.archive.yaml \
 	tests/org.test.Deprecated.SHA1.file.json \
+	tests/org.test.Deprecated.SHA1.file.yaml \
 	tests/hello.sh \
 	tests/hello.tar.xz \
 	$(NULL)


### PR DESCRIPTION
* tests: Don't install buildutil/tap-driver.sh
    
    This is not necessary for the "as-installed" tests, and happens to cause
    lint warnings from Debian's Lintian tool.

* tests: Install all deprecation tests when installed-tests are enabled

    Resolves: #511 