### PR TITLE
Ignore $schema properties in manifests

### DIFF
--- a/data/flatpak-manifest.schema.json
+++ b/data/flatpak-manifest.schema.json
@@ -8,6 +8,9 @@
       },
       "comment": {
         "description": "Comment property (ignored by flatpak-builder)"
+      },
+      "schema": {
+        "description": "JSON schema (ignored by flatpak-builder)"
       }
     },
     "build-options": {
@@ -1438,7 +1441,8 @@
   },
   "patternProperties": {
     "^x-.*": { "$ref": "#/$defs/ignored-prop/custom" },
-    "^//.*": { "$ref": "#/$defs/ignored-prop/comment" }
+    "^//.*": { "$ref": "#/$defs/ignored-prop/comment" },
+    "^\\$schema$": { "$ref": "#/$defs/ignored-prop/schema" }
   },
   "allOf": [
     {

--- a/src/builder-utils.c
+++ b/src/builder-utils.c
@@ -1255,7 +1255,8 @@ builder_serializable_find_property (JsonSerializable *serializable,
 
   if (pspec == NULL &&
       !g_str_has_prefix (name, "__") &&
-      !g_str_has_prefix (name, "//"))
+      !g_str_has_prefix (name, "//") &&
+      g_strcmp0 (name, "$schema"))
     g_warning ("Unknown property %s for type %s", name, g_type_name_from_instance ((GTypeInstance *)serializable));
 
   return pspec;


### PR DESCRIPTION
This is used by various tools to specify a JSON schema.

Fixes #515