### PR TITLE
Port to libappstream

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,7 +24,7 @@ jobs:
         libfuse-dev ostree libostree-dev libarchive-dev libcap-dev libattr1-dev libdw-dev libelf-dev \
         libjson-glib-dev shared-mime-info desktop-file-utils libpolkit-agent-1-dev libpolkit-gobject-1-dev \
         libseccomp-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
-        libgirepository1.0-dev libappstream-glib-dev libdconf-dev clang socat flatpak \
+        libgirepository1.0-dev libappstream-dev libdconf-dev clang flatpak \
         libcurl4-gnutls-dev libflatpak-dev libyaml-dev elfutils git patch unzip
     - name: Check out flatpak
       uses: actions/checkout@v1
@@ -53,7 +53,7 @@ jobs:
         libfuse-dev ostree libostree-dev libarchive-dev libcap-dev libattr1-dev libdw-dev libelf-dev \
         libjson-glib-dev shared-mime-info desktop-file-utils libpolkit-agent-1-dev libpolkit-gobject-1-dev \
         libseccomp-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
-        libgirepository1.0-dev libappstream-glib-dev libdconf-dev clang flatpak \
+        libgirepository1.0-dev libappstream-dev libdconf-dev clang flatpak \
         libcurl4-gnutls-dev libflatpak-dev libyaml-dev elfutils git patch unzip
     - name: Check out flatpak
       uses: actions/checkout@v1
@@ -101,7 +101,7 @@ jobs:
           git \
           gobject-introspection \
           gtk-doc-tools \
-          libappstream-glib-dev \
+          libappstream-dev \
           libarchive-dev \
           libattr1-dev \
           libcap-dev \

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,11 +20,11 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libglib2.0 attr automake gettext autopoint bison  dbus gtk-doc-tools \
+        sudo apt-get install -y libglib2.0 attr automake appstream-compose gettext autopoint bison dbus gtk-doc-tools \
         libfuse-dev ostree libostree-dev libarchive-dev libcap-dev libattr1-dev libdw-dev libelf-dev \
         libjson-glib-dev shared-mime-info desktop-file-utils libpolkit-agent-1-dev libpolkit-gobject-1-dev \
         libseccomp-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
-        libgirepository1.0-dev libappstream-dev libdconf-dev clang flatpak \
+        libgirepository1.0-dev libappstream-dev libdconf-dev clang socat flatpak \
         libcurl4-gnutls-dev libflatpak-dev libyaml-dev elfutils git patch unzip
     - name: Check out flatpak
       uses: actions/checkout@v1
@@ -49,7 +49,7 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libglib2.0 attr automake gettext autopoint bison  dbus gtk-doc-tools \
+        sudo apt-get install -y libglib2.0 attr automake appstream-compose gettext autopoint bison dbus gtk-doc-tools \
         libfuse-dev ostree libostree-dev libarchive-dev libcap-dev libattr1-dev libdw-dev libelf-dev \
         libjson-glib-dev shared-mime-info desktop-file-utils libpolkit-agent-1-dev libpolkit-gobject-1-dev \
         libseccomp-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
@@ -91,6 +91,7 @@ jobs:
           attr \
           automake \
           autopoint \
+          appstream-compose \
           bison \
           debugedit \
           dbus \

--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,4 @@ system-helper/org.freedesktop.Flatpak.policy
 system-helper/org.freedesktop.Flatpak.rules
 flatpak-bwrap
 py-compile
+libglnx-config.h

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -8,7 +8,7 @@ dn=$(dirname $0)
 
 pkg_install sudo which attr fuse \
     libubsan libasan libtsan elfutils-libelf-devel libdwarf-devel \
-    elfutils git gettext-devel libappstream-glib-devel bison \
+    elfutils git gettext-devel libappstream-devel bison \
     libcurl-devel dconf-devel fuse-devel \
     /usr/bin/{update-mime-database,update-desktop-database,gtk-update-icon-cache}
 pkg_install_testing ostree-devel ostree libyaml-devel

--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,7 @@ AC_DEFINE([GLIB_VERSION_MAX_ALLOWED], [GLIB_VERSION_2_68], [Glib max version])
 GLIB_REQS=2.66
 OSTREE_REQS=2017.14
 FLATPAK_REQS=0.99.1
+APPSTREAMCLI_REQS=0.15.0
 SYSTEM_DEBUGEDIT_REQS=5.0
 LIBDW_REQS=0.172
 
@@ -40,6 +41,21 @@ else
                       [AC_MSG_ERROR([You need at least version $FLATPAK_REQS of flatpak, your version is $FLATPAK_VERSION])])
 fi
 
+AC_CHECK_PROG([APPSTREAMCLI], [appstreamcli], [appstreamcli], [false])
+if test "x$APPSTREAMCLI" = xfalse; then
+   AC_MSG_ERROR([You need appstreamcli installed])
+   APPSTREAMCLI_VERSION=`$APPSTREAMCLI --version | sed 's,.*\ \([0-9]*\.[0-9]*\.[0-9]*\)$,\1,'`
+   AX_COMPARE_VERSION([$APPSTREAMCLI_REQS],[gt],[$APPSTREAMCLI_VERSION],
+                      [AC_MSG_ERROR([You need at least version $APPSTREAMCLI_REQS of appstreamcli, your version is $APPSTREAMCLI_VERSION])])
+fi
+
+AC_MSG_CHECKING([whether appstreamcli has compose support])
+AS_IF([appstreamcli compose --help >/dev/null 2>&1],
+      [AC_MSG_RESULT(yes)],
+      [
+       AC_MSG_RESULT(no)
+       AC_MSG_ERROR([appstreamcli must have compose support enabled and installed])
+      ])
 
 LT_PREREQ([2.2.6])
 LT_INIT([disable-static])

--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -168,7 +168,7 @@
                 </varlistentry>
                 <varlistentry>
                     <term><option>appstream-compose</option> (boolean)</term>
-                    <listitem><para>Run <command>appstreamcli-compose</command> during cleanup phase. Defaults to true.</para></listitem>
+                    <listitem><para>Run <command>appstreamcli compose</command> during cleanup phase. Defaults to true.</para></listitem>
                 </varlistentry>
                 <varlistentry>
                     <term><option>sdk-extensions</option> (array of strings)</term>

--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -168,7 +168,7 @@
                 </varlistentry>
                 <varlistentry>
                     <term><option>appstream-compose</option> (boolean)</term>
-                    <listitem><para>Run appstream-compose during cleanup phase. Defaults to true.</para></listitem>
+                    <listitem><para>Run <command>appstreamcli-compose</command> during cleanup phase. Defaults to true.</para></listitem>
                 </varlistentry>
                 <varlistentry>
                     <term><option>sdk-extensions</option> (array of strings)</term>

--- a/meson.build
+++ b/meson.build
@@ -40,6 +40,10 @@ endforeach
 # The debugedit program is a hard dependency
 debugedit = find_program('debugedit', version: '>= 5.0')
 
+# Require appstream with compose plugin installed
+appstreamcli = find_program('appstreamcli', version: '>= 0.15.0')
+appstreamcli_compose = run_command(appstreamcli, ['--help'], check: true)
+
 subdir('src')
 subdir('doc')
 if get_option('tests')

--- a/meson.build
+++ b/meson.build
@@ -42,7 +42,7 @@ debugedit = find_program('debugedit', version: '>= 5.0')
 
 # Require appstream with compose plugin installed
 appstreamcli = find_program('appstreamcli', version: '>= 0.15.0')
-appstreamcli_compose = run_command(appstreamcli, ['--help'], check: true)
+appstreamcli_compose = run_command(appstreamcli, ['compose', '--help'], check: true)
 
 subdir('src')
 subdir('doc')

--- a/src/builder-context.c
+++ b/src/builder-context.c
@@ -81,6 +81,8 @@ struct BuilderContext
   gboolean        have_rofiles;
   gboolean        run_tests;
   gboolean        no_shallow_clone;
+  gboolean        opt_export_only;
+  char           *opt_mirror_screenshots_url;
 
   BuilderSdkConfig *sdk_config;
 };
@@ -342,6 +344,32 @@ builder_context_find_in_sources_dirs_va (BuilderContext *self,
     }
 
   return NULL;
+}
+
+void
+builder_context_set_opt_export_only (BuilderContext *self,
+                                     gboolean       opt_export_only)
+{
+  self->opt_export_only = opt_export_only;
+}
+
+gboolean
+builder_context_get_opt_export_only (BuilderContext *self)
+{
+  return self->opt_export_only;
+}
+
+void
+builder_context_set_opt_mirror_screenshots_url (BuilderContext *self,
+                                                const char     *opt_mirror_screenshots_url)
+{
+  self->opt_mirror_screenshots_url = g_strdup(opt_mirror_screenshots_url);
+}
+
+const char *
+builder_context_get_opt_mirror_screenshots_url (BuilderContext *self)
+{
+  return self->opt_mirror_screenshots_url;
 }
 
 GFile *

--- a/src/builder-context.h
+++ b/src/builder-context.h
@@ -169,6 +169,16 @@ gboolean        builder_context_load_sdk_config (BuilderContext       *self,
                                                  const char           *sdk_path,
                                                  GError              **error);
 
+void            builder_context_set_opt_export_only (BuilderContext *self,
+                                                     gboolean opt_export_only);
+
+gboolean        builder_context_get_opt_export_only (BuilderContext *self);
+
+void            builder_context_set_opt_mirror_screenshots_url (BuilderContext *self,
+                                                                const char *opt_mirror_screenshots_url);
+
+const char *    builder_context_get_opt_mirror_screenshots_url (BuilderContext *self);
+
 BuilderSdkConfig * builder_context_get_sdk_config (BuilderContext *self);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (BuilderContext, g_object_unref)

--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -944,18 +944,8 @@ main (int    argc,
       g_autoptr(GFile) cache = flatpak_build_file (builder_context_get_state_dir (build_context), "screenshots-cache", NULL);
       g_autoptr(GFile) screenshots = flatpak_build_file (app_dir, "screenshots", NULL);
       g_autoptr(GFile) screenshots_sub = flatpak_build_file (screenshots, screenshot_subdir, NULL);
-      g_autofree char *fs_app_dir = g_strdup_printf ("--filesystem=%s", flatpak_file_get_path_cached (app_dir));
-      g_autofree char *fs_cache = g_strdup_printf ("--filesystem=%s", flatpak_file_get_path_cached (cache));
       const char *argv[] = {
-        "flatpak",
-        "build",
-        "--die-with-parent",
-        "--nofilesystem=host:reset",
-        fs_app_dir,
-        fs_cache,
-        "--share=network",
-        flatpak_file_get_path_cached (app_dir),
-        "appstreamcli-compose",
+        "appstreamcli", "compose",
         "--media-baseurl", url,
         "--media-dir", flatpak_file_get_path_cached (screenshots_sub),
         flatpak_file_get_path_cached (xml),
@@ -983,12 +973,12 @@ main (int    argc,
               g_printerr ("Error mirroring screenshots: %s\n", error->message);
               return 1;
             }
-          if (!builder_maybe_host_spawnv (NULL,
-                                          NULL,
-                                          0,
-                                          &error,
-                                          argv,
-                                          NULL))
+          if (!flatpak_spawnv (NULL,
+                               NULL,
+                               0,
+                               &error,
+                               argv,
+                               NULL))
             {
               g_printerr ("Error mirroring screenshots: %s\n", error->message);
               return 1;

--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -955,12 +955,10 @@ main (int    argc,
         fs_cache,
         "--share=network",
         flatpak_file_get_path_cached (app_dir),
-        "appstream-util",
-        "mirror-screenshots",
+        "appstreamcli-compose",
+        "--media-baseurl", url,
+        "--media-dir", flatpak_file_get_path_cached (screenshots_sub),
         flatpak_file_get_path_cached (xml),
-        url,
-        flatpak_file_get_path_cached (cache),
-        flatpak_file_get_path_cached (screenshots_sub),
         NULL
       };
 

--- a/src/builder-manifest.c
+++ b/src/builder-manifest.c
@@ -2775,6 +2775,7 @@ builder_manifest_cleanup (BuilderManifest *self,
           g_autofree char *result_root_arg = g_strdup_printf ("--result-root=%s", app_root_path);
           g_autoptr(GFile) xml_dir = flatpak_build_file (app_root, "share/app-info/xmls", NULL);
           g_autoptr(GFile) icon_out = flatpak_build_file (app_root, "share/app-info/icons/flatpak", NULL);
+          g_autoptr(GFile) media_dir = flatpak_build_file (app_root, "share/app-info/media", NULL);
           g_autofree char *data_dir = g_strdup_printf ("--data-dir=%s",
                                                        flatpak_file_get_path_cached (xml_dir));
           g_autofree char *icon_dir = g_strdup_printf ("--icons-dir=%s",
@@ -2791,7 +2792,7 @@ builder_manifest_cleanup (BuilderManifest *self,
               g_autoptr(GFile) screenshots = flatpak_build_file (app_root, "screenshots", NULL);
               g_autofree char *arg_base_url = g_strdup_printf ("--media-baseurl=%s", url);
               g_autofree char *arg_media_dir =  g_strdup_printf ("--media-dir=%s",
-                                                                 flatpak_file_get_path_cached (screenshots));
+                                                                 flatpak_file_get_path_cached (media_dir));
 
               g_print ("Running appstreamcli compose\n");
               g_print ("Saving screenshots in %s\n", flatpak_file_get_path_cached (screenshots));

--- a/src/builder-manifest.c
+++ b/src/builder-manifest.c
@@ -2785,17 +2785,13 @@ builder_manifest_cleanup (BuilderManifest *self,
 
           if (opt_mirror_screenshots_url && !opt_export_only)
             {
-              g_autofree char *screenshot_subdir = g_strdup_printf ("%s-%s",
-                                                                    builder_manifest_get_id (self),
-                                                                    builder_manifest_get_branch (self, context));
-              g_autofree char *url = g_build_filename (opt_mirror_screenshots_url, screenshot_subdir, NULL);
-              g_autoptr(GFile) screenshots = flatpak_build_file (app_root, "screenshots", NULL);
+              g_autofree char *url = g_build_filename (opt_mirror_screenshots_url, NULL);
               g_autofree char *arg_base_url = g_strdup_printf ("--media-baseurl=%s", url);
               g_autofree char *arg_media_dir =  g_strdup_printf ("--media-dir=%s",
                                                                  flatpak_file_get_path_cached (media_dir));
 
               g_print ("Running appstreamcli compose\n");
-              g_print ("Saving screenshots in %s\n", flatpak_file_get_path_cached (screenshots));
+              g_print ("Saving screenshots in %s\n", flatpak_file_get_path_cached (media_dir));
               if (!appstreamcli_compose (error,
                                          "--prefix=/",
                                          origin,

--- a/src/builder-manifest.c
+++ b/src/builder-manifest.c
@@ -2314,8 +2314,7 @@ cmpstringp (const void *p1, const void *p2)
 }
 
 static gboolean
-appstreamcli_compose (GFile   *app_dir,
-                      GError **error,
+appstreamcli_compose (GError **error,
                       ...)
 {
   g_autoptr(GPtrArray) args = NULL;
@@ -2323,12 +2322,8 @@ appstreamcli_compose (GFile   *app_dir,
   va_list ap;
 
   args = g_ptr_array_new_with_free_func (g_free);
-  g_ptr_array_add (args, g_strdup ("flatpak"));
-  g_ptr_array_add (args, g_strdup ("build"));
-  g_ptr_array_add (args, g_strdup ("--die-with-parent"));
-  g_ptr_array_add (args, g_strdup ("--nofilesystem=host:reset"));
-  g_ptr_array_add (args, g_file_get_path (app_dir));
-  g_ptr_array_add (args, g_strdup ("appstreamcli-compose"));
+  g_ptr_array_add (args, g_strdup ("appstreamcli"));
+  g_ptr_array_add (args, g_strdup ("compose"));
 
   va_start (ap, error);
   while ((arg = va_arg (ap, const gchar *)))
@@ -2336,9 +2331,9 @@ appstreamcli_compose (GFile   *app_dir,
   g_ptr_array_add (args, NULL);
   va_end (ap);
 
-  if (!builder_maybe_host_spawnv (NULL, NULL, 0, error, (const char * const *)args->pdata, NULL))
+  if (!flatpak_spawnv (NULL, NULL, 0, error, (const char * const *)args->pdata, NULL))
     {
-      g_prefix_error (error, "ERROR: appstreamcli-compose failed: ");
+      g_prefix_error (error, "ERROR: appstreamcli compose failed: ");
       return FALSE;
     }
 
@@ -2773,17 +2768,17 @@ builder_manifest_cleanup (BuilderManifest *self,
 
       if (self->appstream_compose && appdata_file != NULL)
         {
-          g_autofree char *app_root_path = g_file_get_path (app_root);
-          g_autofree char *prefix_arg = g_strdup_printf ("--prefix=%s", app_root_path);
-          g_autofree char *basename_arg = g_strdup_printf ("--basename=%s", self->id);
           g_autofree char *components_arg = g_strdup_printf ("--components=%s", self->id);
-          g_print ("Running appstreamcli-compose\n");
-          if (!appstreamcli_compose (app_dir, error,
-                                     self->build_runtime ?  "--prefix=/usr" : "--prefix=/app",
+          g_autofree char *app_root_path = g_file_get_path (app_root);
+          g_autofree char *result_root_arg = g_strdup_printf ("--result-root=%s", app_root_path);
+
+          g_print ("Running appstreamcli compose\n");
+          if (!appstreamcli_compose (error,
+                                     "--prefix=/",
                                      "--origin=flatpak",
-                                     "--result-root=/",
+                                     result_root_arg,
                                      components_arg,
-                                     "/",
+                                     app_root_path,
                                      NULL))
             return FALSE;
         }


### PR DESCRIPTION
This the completed port to libappstream with a counterpart on the flatpak side(https://github.com/flatpak/flatpak/pull/5277). It is based of off @pwithnall and @barthalion previous work. 
Reasoning has been taken from @pwithnall's original pr
> appstream-glib is mostly unmaintained, and appstream is more
actively developed (and up to date with the AppStream specification).

> This ports flatpak-builder to use the command line tools from appstream
(appstreamcli and appstreamcli-compose) rather than the ones from
appstream-glib (appstream-util, appstream-builder and
appstream-compose).

> This should result in no changes for most things, but should fix
propagation of \<requires>/\<recommends> elements, screenshot
>\<caption>s, and other elements which have been added to the AppStream
specification recently.

> For example, see https://github.com/flathub/flathub/issues/2439

Signed-off-by: Luna D Dragon [luna.dragon@suse.com](mailto:luna.dragon@suse.com)