### PR TITLE
Fix manifest containing the wrong no-autodownload value

### DIFF
--- a/src/builder-extension.c
+++ b/src/builder-extension.c
@@ -127,7 +127,7 @@ builder_extension_get_property (GObject    *object,
       break;
 
     case PROP_NO_AUTODOWNLOAD:
-      g_value_set_boolean (value, self->autodelete);
+      g_value_set_boolean (value, self->no_autodownload);
       break;
 
     case PROP_LOCALE_SUBSET:


### PR DESCRIPTION
Fix copy/paste error that made the "no-autodownload" value in /app/manifest.json, showing the "autodelete" value instead.

Fixes: c6ef29c06b110 ("builder: Add support for defining extensions in flatpak-builder"