### PR TITLE
Document that config-opts is used for CMake

### DIFF
--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -389,7 +389,7 @@
                 </varlistentry>
                 <varlistentry>
                     <term><option>config-opts</option> (array of strings)</term>
-                    <listitem><para>This is an array containing extra options to pass to configure or cmake.</para></listitem>
+                    <listitem><para>This is an array containing extra options passed to the build system during configuration.</para></listitem>
                 </varlistentry>
                 <varlistentry>
                     <term><option>secret-opts</option> (array of strings)</term>

--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -389,7 +389,7 @@
                 </varlistentry>
                 <varlistentry>
                     <term><option>config-opts</option> (array of strings)</term>
-                    <listitem><para>This is an array containing extra options to pass to configure.</para></listitem>
+                    <listitem><para>This is an array containing extra options to pass to configure or cmake.</para></listitem>
                 </varlistentry>
                 <varlistentry>
                     <term><option>secret-opts</option> (array of strings)</term>


### PR DESCRIPTION
It's not clear from the docs that `config-opts` is used for the cmake buildsystem as well as autotools.