### PR TITLE
build: Distribute Meson build files for libglnx subproject

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -98,3 +98,14 @@ AM_DISTCHECK_CONFIGURE_FLAGS =		\
 	--enable-documentation		\
 	--disable-maintainer-mode	\
 	--enable-introspection
+
+distcheck-hook: distcheck-hook-meson
+distcheck-hook-meson:
+	set -e; if command -v meson > /dev/null; then \
+		cd $(distdir); \
+		pwd; \
+		meson setup _build/meson; \
+		meson compile -C _build/meson -v; \
+		meson test -C _build/meson -v; \
+		rm -fr _build/meson; \
+	fi

--- a/Makefile.am
+++ b/Makefile.am
@@ -88,6 +88,9 @@ EXTRA_DIST += 			\
 	src/meson.build		\
 	tests/meson.build \
 	subprojects/libglnx.wrap \
+	subprojects/libglnx/meson.build \
+	subprojects/libglnx/meson_options.txt \
+	subprojects/libglnx/tests/meson.build \
 	subprojects/libyaml.wrap \
 	$(NULL)
 


### PR DESCRIPTION
* build: Distribute Meson build files for libglnx subproject
    
    Resolves: https://github.com/flatpak/flatpak-builder/issues/530

* build: During distcheck, verify that all required Meson files are included
    
    Reproduces: https://github.com/flatpak/flatpak-builder/issues/530

cc @amigadave 