### PR TITLE
meson: Reinstate parallel tests, add as-installed testing

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -87,6 +87,8 @@ EXTRA_DIST += 			\
 	doc/meson.build		\
 	src/meson.build		\
 	tests/meson.build \
+	tests/test-keyring/meson.build \
+	tests/test-keyring2/meson.build \
 	subprojects/libglnx.wrap \
 	subprojects/libglnx/meson.build \
 	subprojects/libglnx/meson_options.txt \

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -11,6 +11,12 @@ option(
   description: 'Whether to build the DocBook documentation and man pages'
 )
 option(
+  'installed_tests',
+  type : 'boolean',
+  description : 'install automated tests',
+  value : false,
+)
+option(
   'tests',
   type: 'boolean',
   value: true,

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -10,12 +10,17 @@ test_names = [
   'test-builder-python',
 ]
 
+tap_test = find_program(
+  files(meson.project_source_root() / 'buildutil/tap-test'),
+)
+
 foreach test_name : test_names
-  test_script = find_program(test_name + '.sh')
+  filename = test_name + '.sh'
 
   test(
     test_name,
-    test_script,
+    tap_test,
+    args: [files(filename)],
     is_parallel: false, # FIXME
     env: test_env,
     depends: flatpak_builder,

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -21,7 +21,6 @@ foreach test_name : test_names
     test_name,
     tap_test,
     args: [files(filename)],
-    is_parallel: false, # FIXME
     env: test_env,
     depends: flatpak_builder,
     workdir: meson.current_build_dir(),

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,3 +1,6 @@
+installed_testdir = get_option('prefix') / get_option('libexecdir') / 'installed-tests' / 'flatpak-builder'
+installed_tests_metadir = get_option('prefix') / get_option('datadir') / 'installed-tests' / 'flatpak-builder'
+
 test_env = environment()
 test_env.set('FLATPAK_TESTS_DEBUG', '1')
 test_env.set('G_TEST_SRCDIR', meson.current_source_dir())
@@ -25,4 +28,78 @@ foreach test_name : test_names
     depends: flatpak_builder,
     workdir: meson.current_build_dir(),
   )
+
+  if get_option('installed_tests')
+    install_data(
+      filename,
+      install_dir : installed_testdir,
+      install_mode : 'rwxr-xr-x',
+    )
+    configure_file(
+      input: 'tap.test.in',
+      output: filename + '.test',
+      configuration: {
+        # After dropping Autotools we could use test_name here (avoiding the
+        # redudant .sh), but for now include the .sh to keep the installed
+        # files easier to compare with Autotools
+        'basename': filename,
+        'installed_testdir': installed_testdir,
+        'wrapper': '',
+      },
+      install_dir: installed_tests_metadir,
+    )
+  endif
 endforeach
+
+if get_option('installed_tests')
+  install_data(
+    'empty-configure',
+    'make-test-app.sh',
+    'make-test-bundles.sh',
+    'make-test-runtime.sh',
+    'test-configure',
+    'testpython.py',
+
+    install_dir: installed_testdir,
+    install_mode: 'rwxr-xr-x',
+  )
+  install_data(
+    '0001-Add-test-logo.patch',
+    'data1',
+    'data1.patch',
+    'data2',
+    'data2.patch',
+    'hello.sh',
+    'hello.tar.xz',
+    'importme.py',
+    'importme2.py',
+    'libtest.sh',
+    'module1.json',
+    'module1.yaml',
+    'module2.json',
+    'module2.yaml',
+    'org.test.Deprecated.MD5.archive.json',
+    'org.test.Deprecated.MD5.archive.yaml',
+    'org.test.Deprecated.MD5.file.json',
+    'org.test.Deprecated.MD5.file.yaml',
+    'org.test.Deprecated.SHA1.archive.json',
+    'org.test.Deprecated.SHA1.archive.yaml',
+    'org.test.Deprecated.SHA1.file.json',
+    'org.test.Deprecated.SHA1.file.yaml',
+    'org.test.Hello.png',
+    'org.test.Python.json',
+    'org.test.Python2.json',
+    'session.conf.in',
+    'source1.json',
+    'source2.json',
+    'test-runtime.json',
+    'test.json',
+    'test.yaml',
+
+    install_dir: installed_testdir,
+    install_mode: 'rw-r--r--',
+  )
+endif
+
+subdir('test-keyring')
+subdir('test-keyring2')

--- a/tests/tap.test.in
+++ b/tests/tap.test.in
@@ -1,0 +1,4 @@
+[Test]
+Type=session
+Exec=env G_TEST_SRCDIR=@installed_testdir@ G_TEST_BUILDDIR=@installed_testdir@ @wrapper@ @installed_testdir@/@basename@ --tap
+Output=TAP

--- a/tests/test-keyring/meson.build
+++ b/tests/test-keyring/meson.build
@@ -1,0 +1,10 @@
+if get_option('installed_tests')
+  install_data(
+    'README',
+    'pubring.gpg',
+    'secring.gpg',
+
+    install_dir : installed_testdir / 'test-keyring',
+    install_mode : 'rw-r--r--',
+  )
+endif

--- a/tests/test-keyring2/meson.build
+++ b/tests/test-keyring2/meson.build
@@ -1,0 +1,10 @@
+if get_option('installed_tests')
+  install_data(
+    'README',
+    'pubring.gpg',
+    'secring.gpg',
+
+    install_dir : installed_testdir / 'test-keyring2',
+    install_mode : 'rw-r--r--',
+  )
+endif


### PR DESCRIPTION
* tests: Run each test in a new, empty directory
    
    The test framework in libtest.sh expects this, and it's what the
    Autotools build system did.

* tests: Run in parallel
    
    Now that each test has its own working directory, hopefully we can run
    them in parallel.

* tests: Add GNOME-style installed tests to Meson build
    
    This was supported with Autotools, but missing from Meson until now.
    
    Resolves: https://github.com/flatpak/flatpak-builder/issues/528