### PR TITLE
build: Fix Meson build when yaml is disabled

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -25,8 +25,10 @@ flatpak_builder_sources = files(
   'builder-utils.c',
 )
 
+yaml_dep = dependency('yaml-0.1', required: get_option('yaml'))
+
 config_data = configuration_data()
-config_data.set10('FLATPAK_BUILDER_ENABLE_YAML', true)
+config_data.set('FLATPAK_BUILDER_ENABLE_YAML', yaml_dep.found())
 config_data.set_quoted('DEBUGEDIT', debugedit.full_path())
 config_data.set_quoted('GETTEXT_PACKAGE', meson.project_name())
 config_data.set_quoted('PACKAGE_VERSION', meson.project_version())
@@ -55,7 +57,7 @@ flatpak_builder_deps = [
   dependency('libglnx', default_options: ['tests=false']),
   dependency('libxml-2.0', version: '>= 2.4'),
   dependency('ostree-1', version: '>= 2017.14'),
-  dependency('yaml-0.1', required: get_option('yaml')),
+  yaml_dep,
 ]
 
 flatpak_builder = executable(


### PR DESCRIPTION
This had two issues in the Meson build system: it was always set to true even if configured with `-Dyaml=disabled`, and the `#ifdef FLATPAK_BUILDER_ENABLE_YAML` check always succeeded because `set10` defines the macro to 1 or 0. Use `set` with a boolean value instead, which defines or undefines the macro, leading to the same interface as in Autotools.

---

This is not hugely important, I don't know whether anyone actually disables YAML in practice - it's an extra dependency, but YAML is so much nicer as a human-written format than JSON.

The other possibility here would be to remove the option, and say that 1.3.x/1.4.x unconditionally supports YAML manifests.