### PR TITLE
Use TAP for Meson tests

### DIFF
--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -312,7 +312,7 @@ skip_without_python2 () {
 cleanup () {
     gpg-connect-agent --homedir "${FL_GPG_HOMEDIR}" killagent /bye >&2 || true
     if test -n "${TEST_SKIP_CLEANUP:-}"; then
-        echo "Skipping cleanup of ${TEST_DATA_DIR}"
+        echo "# Skipping cleanup of ${TEST_DATA_DIR}"
     else
         rm -rf $TEST_DATA_DIR
     fi

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -214,7 +214,7 @@ setup_repo () {
         collection_args=
     fi
 
-    flatpak remote-add ${U} ${collection_args} ${import_args} ${REPONAME}-repo repos/$REPONAME
+    flatpak remote-add ${U} ${collection_args} ${import_args} ${REPONAME}-repo repos/$REPONAME >&2
 }
 
 update_repo () {
@@ -227,7 +227,7 @@ update_repo () {
         collection_args=
     fi
 
-    ${FLATPAK} build-update-repo ${collection_args} ${GPGARGS:-${FL_GPGARGS}} ${UPDATE_REPO_ARGS-} repos/${REPONAME}
+    ${FLATPAK} build-update-repo ${collection_args} ${GPGARGS:-${FL_GPGARGS}} ${UPDATE_REPO_ARGS-} repos/${REPONAME} >&2
 }
 
 make_updated_app () {
@@ -269,19 +269,19 @@ setup_python2_repo () {
 
 install_repo () {
     REPONAME=${1:-test}
-    ${FLATPAK} ${U} install -y ${REPONAME}-repo org.test.Platform master
-    ${FLATPAK} ${U} install -y ${REPONAME}-repo org.test.Hello master
+    ${FLATPAK} ${U} install -y ${REPONAME}-repo org.test.Platform master >&2
+    ${FLATPAK} ${U} install -y ${REPONAME}-repo org.test.Hello master >&2
 }
 
 install_sdk_repo () {
     REPONAME=${1:-test}
-    ${FLATPAK} ${U} install -y ${REPONAME}-repo org.test.Sdk master
+    ${FLATPAK} ${U} install -y ${REPONAME}-repo org.test.Sdk master >&2
 }
 
 install_python2_repo () {
     REPONAME=${1:-test}
-    ${FLATPAK} ${U} install -y ${REPONAME}-repo org.test.PythonPlatform master
-    ${FLATPAK} ${U} install -y ${REPONAME}-repo org.test.PythonSdk master
+    ${FLATPAK} ${U} install -y ${REPONAME}-repo org.test.PythonPlatform master >&2
+    ${FLATPAK} ${U} install -y ${REPONAME}-repo org.test.PythonSdk master >&2
 }
 
 run () {
@@ -310,7 +310,7 @@ skip_without_python2 () {
 }
 
 cleanup () {
-    gpg-connect-agent --homedir "${FL_GPG_HOMEDIR}" killagent /bye || true
+    gpg-connect-agent --homedir "${FL_GPG_HOMEDIR}" killagent /bye >&2 || true
     if test -n "${TEST_SKIP_CLEANUP:-}"; then
         echo "Skipping cleanup of ${TEST_DATA_DIR}"
     else

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -26,6 +26,7 @@ foreach test_name : test_names
     args: [files(filename)],
     env: test_env,
     depends: flatpak_builder,
+    protocol: 'tap',
     workdir: meson.current_build_dir(),
   )
 

--- a/tests/test-builder-deprecated.sh
+++ b/tests/test-builder-deprecated.sh
@@ -42,49 +42,49 @@ cp "$srcdir"/org.test.Deprecated.SHA1.file.yaml .
 cp "$srcdir"/hello.sh .
 cp "$srcdir"/hello.tar.xz .
 
-${FLATPAK_BUILDER} --force-clean appdir org.test.Deprecated.MD5.archive.json 2> build-error-log
+${FLATPAK_BUILDER} --force-clean appdir org.test.Deprecated.MD5.archive.json >&2 2> build-error-log
 assert_file_has_content build-error-log 'The "md5" source property is deprecated due to the weakness of MD5 hashes.'
 assert_file_has_content build-error-log 'Use the "sha256" property for the more secure SHA256 hash.'
 
 echo "ok deprecated MD5 hash for archive in JSON"
 
-${FLATPAK_BUILDER} --force-clean appdir org.test.Deprecated.MD5.archive.yaml 2> build-error-log
+${FLATPAK_BUILDER} --force-clean appdir org.test.Deprecated.MD5.archive.yaml >&2 2> build-error-log
 assert_file_has_content build-error-log 'The "md5" source property is deprecated due to the weakness of MD5 hashes.'
 assert_file_has_content build-error-log 'Use the "sha256" property for the more secure SHA256 hash.'
 
 echo "ok deprecated MD5 hash for archive in YAML"
 
-${FLATPAK_BUILDER} --force-clean appdir org.test.Deprecated.MD5.file.json 2> build-error-log
+${FLATPAK_BUILDER} --force-clean appdir org.test.Deprecated.MD5.file.json >&2 2> build-error-log
 assert_file_has_content build-error-log 'The "md5" source property is deprecated due to the weakness of MD5 hashes.'
 assert_file_has_content build-error-log 'Use the "sha256" property for the more secure SHA256 hash.'
 
 echo "ok deprecated MD5 hash for file in JSON"
 
-${FLATPAK_BUILDER} --force-clean appdir org.test.Deprecated.MD5.file.yaml 2> build-error-log
+${FLATPAK_BUILDER} --force-clean appdir org.test.Deprecated.MD5.file.yaml >&2 2> build-error-log
 assert_file_has_content build-error-log 'The "md5" source property is deprecated due to the weakness of MD5 hashes.'
 assert_file_has_content build-error-log 'Use the "sha256" property for the more secure SHA256 hash.'
 
 echo "ok deprecated MD5 hash for file in YAML"
 
-${FLATPAK_BUILDER} --force-clean appdir org.test.Deprecated.SHA1.archive.json 2> build-error-log
+${FLATPAK_BUILDER} --force-clean appdir org.test.Deprecated.SHA1.archive.json >&2 2> build-error-log
 assert_file_has_content build-error-log 'The "sha1" source property is deprecated due to the weakness of SHA1 hashes.'
 assert_file_has_content build-error-log 'Use the "sha256" property for the more secure SHA256 hash.'
 
 echo "ok deprecated SHA1 hash for archive in JSON"
 
-${FLATPAK_BUILDER} --force-clean appdir org.test.Deprecated.SHA1.archive.yaml 2> build-error-log
+${FLATPAK_BUILDER} --force-clean appdir org.test.Deprecated.SHA1.archive.yaml >&2 2> build-error-log
 assert_file_has_content build-error-log 'The "sha1" source property is deprecated due to the weakness of SHA1 hashes.'
 assert_file_has_content build-error-log 'Use the "sha256" property for the more secure SHA256 hash.'
 
 echo "ok deprecated SHA1 hash for archive in YAML"
 
-${FLATPAK_BUILDER} --force-clean appdir org.test.Deprecated.SHA1.file.json 2> build-error-log
+${FLATPAK_BUILDER} --force-clean appdir org.test.Deprecated.SHA1.file.json >&2 2> build-error-log
 assert_file_has_content build-error-log 'The "sha1" source property is deprecated due to the weakness of SHA1 hashes.'
 assert_file_has_content build-error-log 'Use the "sha256" property for the more secure SHA256 hash.'
 
 echo "ok deprecated SHA1 hash for file in JSON"
 
-${FLATPAK_BUILDER} --force-clean appdir org.test.Deprecated.SHA1.file.yaml 2> build-error-log
+${FLATPAK_BUILDER} --force-clean appdir org.test.Deprecated.SHA1.file.yaml >&2 2> build-error-log
 assert_file_has_content build-error-log 'The "sha1" source property is deprecated due to the weakness of SHA1 hashes.'
 assert_file_has_content build-error-log 'Use the "sha256" property for the more secure SHA256 hash.'
 

--- a/tests/test-builder-python.sh
+++ b/tests/test-builder-python.sh
@@ -42,7 +42,7 @@ cp -a $(dirname $0)/testpython.py .
 cp $(dirname $0)/importme.py .
 cp $(dirname $0)/importme2.py .
 chmod u+w *.py
-flatpak-builder --force-clean appdir org.test.Python.json
+flatpak-builder --force-clean appdir org.test.Python.json >&2
 
 assert_has_file appdir/files/bin/importme.pyc
 
@@ -52,7 +52,7 @@ assert_file_has_content testpython.out ^modified$
 
 echo "ok handled pyc rewriting multiple times"
 
-flatpak-builder --force-clean appdir org.test.Python2.json
+flatpak-builder --force-clean appdir org.test.Python2.json >&2
 
 assert_not_has_file appdir/files/bin/importme.py
 assert_has_file appdir/files/bin/importme.pyc

--- a/tests/test-builder.sh
+++ b/tests/test-builder.sh
@@ -52,8 +52,8 @@ cp $(dirname $0)/module2.yaml include1/include2/
 cp $(dirname $0)/source2.json include1/include2/
 cp $(dirname $0)/data2 include1/include2/
 cp $(dirname $0)/data2.patch include1/include2/
-${FLATPAK_BUILDER} --repo=$REPO $FL_GPGARGS --force-clean appdir test.json
-${FLATPAK_BUILDER} --repo=$REPO $FL_GPGARGS --force-clean appdir test.yaml
+${FLATPAK_BUILDER} --repo=$REPO $FL_GPGARGS --force-clean appdir test.json >&2
+${FLATPAK_BUILDER} --repo=$REPO $FL_GPGARGS --force-clean appdir test.yaml >&2
 
 assert_file_has_content appdir/files/share/app-data version1
 assert_file_has_content appdir/metadata shared=network;
@@ -78,7 +78,7 @@ assert_file_has_content hello_out2 '^Hello world2, from a sandbox$'
 
 echo "ok build"
 
-${FLATPAK} ${U} install -y test-repo org.test.Hello2 master
+${FLATPAK} ${U} install -y test-repo org.test.Hello2 master >&2
 run org.test.Hello2 > hello_out3
 assert_file_has_content hello_out3 '^Hello world2, from a sandbox$'
 
@@ -88,12 +88,12 @@ assert_file_has_content app_data_1 version1
 echo "ok install+run"
 
 echo "version2" > app-data
-${FLATPAK_BUILDER} $FL_GPGARGS --repo=$REPO --force-clean appdir test.json
+${FLATPAK_BUILDER} $FL_GPGARGS --repo=$REPO --force-clean appdir test.json >&2
 assert_file_has_content appdir/files/share/app-data version2
-${FLATPAK_BUILDER} $FL_GPGARGS --repo=$REPO --force-clean appdir test.yaml
+${FLATPAK_BUILDER} $FL_GPGARGS --repo=$REPO --force-clean appdir test.yaml >&2
 assert_file_has_content appdir/files/share/app-data version2
 
-${FLATPAK} ${U} update -y org.test.Hello2 master
+${FLATPAK} ${U} update -y org.test.Hello2 master >&2
 
 run --command=cat org.test.Hello2 /app/share/app-data > app_data_2
 assert_file_has_content app_data_2 version2
@@ -103,6 +103,6 @@ echo "ok update"
 # The build-args of --help should prevent the faulty cleanup and
 # platform-cleanup commands from executing
 ${FLATPAK_BUILDER} $FL_GPGARGS --repo=$REPO --force-clean runtimedir \
-    test-runtime.json
+    test-runtime.json >&2
 
 echo "ok runtime build cleanup with build-args"


### PR DESCRIPTION
* tests: Send diagnostic output from Flatpak etc. to stderr
    
    This avoids interfering with the machine-readable TAP output on stdout,
    which should be interpreted by Meson.
    
* tests: Turn an unstructured "echo" into a TAP diagnostic[

* tests: Tell Meson to parse TAP output
    
    Resolves: https://github.com/flatpak/flatpak-builder/issues/529

---

I haven't really tested `test-builder-python.sh` since my distribution no longer supports Python 2, but I think it's right.