### PR TITLE
Add support for ESON manifests

### DIFF
--- a/src/builder-utils.h
+++ b/src/builder-utils.h
@@ -67,6 +67,9 @@ GQuark builder_curl_error_quark (void);
 GQuark builder_yaml_parse_error_quark (void);
 #define BUILDER_YAML_PARSE_ERROR (builder_yaml_parse_error_quark ())
 
+GQuark builder_eson_parse_error_quark (void);
+#define BUILDER_ESON_PARSE_ERROR (builder_eson_parse_error_quark ())
+
 JsonNode * builder_json_node_from_data (const char *relpath,
                                         const char *contents,
                                         GError    **error);

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -24,13 +24,16 @@ dist_installed_test_data = \
 	tests/source2.json \
 	tests/test.json \
 	tests/test.yaml \
+	tests/test.eson \
 	tests/test-runtime.json \
 	tests/module1.json \
 	tests/module1.yaml \
+	tests/module1.eson \
 	tests/data1 \
 	tests/data1.patch \
 	tests/module2.json \
 	tests/module2.yaml \
+	tests/module2.eson \
 	tests/data2 \
 	tests/data2.patch \
 	tests/session.conf.in \

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -77,8 +77,10 @@ if get_option('installed_tests')
     'libtest.sh',
     'module1.json',
     'module1.yaml',
+    'module1.eson',
     'module2.json',
     'module2.yaml',
+    'module2.eson',
     'org.test.Deprecated.MD5.archive.json',
     'org.test.Deprecated.MD5.archive.yaml',
     'org.test.Deprecated.MD5.file.json',
@@ -94,6 +96,7 @@ if get_option('installed_tests')
     'source1.json',
     'source2.json',
     'test-runtime.json',
+    'test.eson',
     'test.json',
     'test.yaml',
 

--- a/tests/module1.eson
+++ b/tests/module1.eson
@@ -1,0 +1,20 @@
+"module1 "name (,,)
+  "include2/module2.eson
+    "module1-first "name (,,)
+    "simple "buildsystem (,,)
+      "echo%20module1%20>%20/app/modify_me
+      "echo%20module1%20>%20/app/ran_module1
+      2 [] "build-commands (,,)
+        "patch "type (,,)
+        0 "strip-components (,,)
+        "data1.patch "path (,,)
+        3 {:}
+
+        "file "type (,,)
+        "data1 "path (,,)
+        2 {:}
+
+        2 [] "sources (,,)
+    4 {:}
+  2 [] "modules (,,)
+2 {:}

--- a/tests/module2.eson
+++ b/tests/module2.eson
@@ -1,0 +1,17 @@
+"module2 "name (,,)
+"simple "buildsystem (,,)
+"/modify_me 1 [] "ensure-writable (,,)
+  "echo%20module2%20>%20/app/modify_me
+  "echo%20module2%20>%20/app/ran_module2
+  2 [] "build-commands (,,)
+
+    "patch "type (,,)
+    "data2.patch "path (,,)
+    2 {:}
+
+    "file "type (,,)
+    "data2 "path (,,)
+    2 {:}
+  2 [] "sources (,,)
+
+5 {:}

--- a/tests/test-builder.sh
+++ b/tests/test-builder.sh
@@ -38,22 +38,26 @@ cp -a $(dirname $0)/test-configure .
 echo "version1" > app-data
 cp $(dirname $0)/test.json .
 cp $(dirname $0)/test.yaml .
+cp $(dirname $0)/test.eson .
 cp $(dirname $0)/test-runtime.json .
 cp $(dirname $0)/0001-Add-test-logo.patch .
 mkdir include1
 cp $(dirname $0)/module1.json include1/
 cp $(dirname $0)/module1.yaml include1/
+cp $(dirname $0)/module1.eson include1/
 cp $(dirname $0)/source1.json include1/
 cp $(dirname $0)/data1 include1/
 cp $(dirname $0)/data1.patch include1/
 mkdir include1/include2
 cp $(dirname $0)/module2.json include1/include2/
 cp $(dirname $0)/module2.yaml include1/include2/
+cp $(dirname $0)/module2.eson include1/include2/
 cp $(dirname $0)/source2.json include1/include2/
 cp $(dirname $0)/data2 include1/include2/
 cp $(dirname $0)/data2.patch include1/include2/
 ${FLATPAK_BUILDER} --repo=$REPO $FL_GPGARGS --force-clean appdir test.json >&2
 ${FLATPAK_BUILDER} --repo=$REPO $FL_GPGARGS --force-clean appdir test.yaml >&2
+${FLATPAK_BUILDER} --repo=$REPO $FL_GPGARGS --force-clean appdir test.eson >&2
 
 assert_file_has_content appdir/files/share/app-data version1
 assert_file_has_content appdir/metadata shared=network;
@@ -91,6 +95,8 @@ echo "version2" > app-data
 ${FLATPAK_BUILDER} $FL_GPGARGS --repo=$REPO --force-clean appdir test.json >&2
 assert_file_has_content appdir/files/share/app-data version2
 ${FLATPAK_BUILDER} $FL_GPGARGS --repo=$REPO --force-clean appdir test.yaml >&2
+assert_file_has_content appdir/files/share/app-data version2
+${FLATPAK_BUILDER} $FL_GPGARGS --repo=$REPO --force-clean appdir test.eson >&2
 assert_file_has_content appdir/files/share/app-data version2
 
 ${FLATPAK} ${U} update -y org.test.Hello2 master >&2

--- a/tests/test.eson
+++ b/tests/test.eson
@@ -1,0 +1,76 @@
+"org.test.Hello2 "app-id (,,)
+"org.test.Platform "runtime (,,)
+"org.test.Sdk "sdk (,,)
+"hello2.sh "command (,,)
+"test 1 [] "tags (,,)
+0 "token-type (,,)
+"--share=network 1 [] "finish-args (,,)
+  "-O2%20-g "cflags (,,)
+  "-O2%20-g "cxxflags (,,)
+    "bar "FOO (,,)
+    "1 "V (,,)
+    2 {:} "env (,,)
+  3 {:} "build-options (,,)
+"*.cleanup "/cleanup 2 [] "cleanup (,,)
+"touch%20/app/cleaned_up 1 [] "cleanup-commands (,,)
+  "root "name (,,)
+      "empty "name (,,)
+      1 {:}
+
+      "test2 "name (,,)
+        "cp%20source[12]%20/app
+        "echo%20foo2%20>%20/app/out2
+        2 [] "build-commands (,,)
+      "simple "buildsystem (,,)
+          "include1/source1.json
+          "include1/include2/source2.json
+
+          "file "type (,,)
+          "app-data "path (,,)
+          2 {:}
+        3 [] "sources (,,)
+      4 {:}
+
+      "test "name (,,)
+      "--some-arg 1 [] "config-opts (,,)
+        "cp%20org.test.Hello.png%20/app/share/icons/
+        "mkdir%20-p%20/app/share/icons/
+        "touch%20/app/bin/file.cleanup
+        3 [] "post-install (,,)
+      "BAR=2 1 [] "make-args (,,)
+      "BAR=3 1 [] "make-install-args (,,)
+      "echo%20foo%20>%20/app/out 1 [] "build-commands (,,)
+          "patch "type (,,)
+          "0001-Add-test-logo.patch "path (,,)
+          T "use-git (,,)
+          3 {:}
+
+          "shell "type (,,)
+            "touch%20/app/cleanup/a_file
+            "mkdir%20/app/cleanup/
+            2 [] "commands (,,)
+          2 {:}
+
+          "script "type (,,)
+          "hello2.sh "dest-filename (,,)
+          "echo%20"Hello%20world2,%20from%20a%20sandbox" 1 [] "commands (,,)
+          3 {:}
+
+          "file "type (,,)
+          "app-data "path (,,)
+          2 {:}
+
+          "file "type (,,)
+          "test-configure "path (,,)
+          "configure "dest-filename (,,)
+          "675a1ac2feec4d4f54e581b4b01bc3cfd2c1cf31aa5963574d31228c8a11b7e7 "sha256 (,,)
+          4 {:}
+        5 [] "sources (,,)
+      7 {:}
+    3 [] "modules (,,)
+  2 {:}
+
+  "include1/module1.eson
+
+  2 [] "modules (,,)
+11 {:}


### PR DESCRIPTION
## Rationale

Right now, flatpak-builder supports two formats for its manifests: JSON and YAML. Unfortunately, the laws of the universe have thus far dictated that all things are terrible, and these are no exception. Consider our `module1.yaml` in the repo:

```yaml
name: module1
modules:
  - name: module1-first
    buildsystem: simple
    build-commands:
      - 'echo module1 > /app/ran_module1'
      - 'echo module1 > /app/modify_me'
    sources:
      - type: file
        path: data1
      - type: patch
        strip-components: 0
        path: data1.patch
  - include2/module2.yaml
```

- :x: Heavy use of indentation makes it unreadable for those used to symbols.
- :x: Observe a random value above. Is it a string? Is it a bool? Is it the origin of life? Unclear without knowing the entire spec from back to front.
- :x: Said spec is 65 letter-size pages.
- :x: Terrible name: recursive acronyms break the laws of space-time, as they cannot be fully expanded without using all available memory in the universe.
- :x: Has too few commas, which is just rude, to such an important, symbol.
- :x: Lets you put comments anywhere in the file, which ruins job security.
- :x: Well-understood by ChatGPT, which will result in the singularity and destroy sandboxing.
- :x: [Hates Norway.](https://www.bram.us/2022/01/11/yaml-the-norway-problem/)

Conclusion: YAML is bad and was presumably added to flatpak-builder by a terrible programmer (seriously, who would want this??).

Unfortunately, JSON is equally terrible overall:

```json
{
    "name": "module1",
    "modules": [
        {
            "name": "module1-first",
            "buildsystem": "simple",
            "build-commands": [
                "echo module1 > /app/ran_module1",
                "echo module1 > /app/modify_me"
            ],
            "sources": [
                {
                    "type": "file",
                    "path": "data1"
                },
                {
                    "type": "patch",
                    "strip-components": 0,
                    "path": "data1.patch"
                }
            ]
        },
        "include2/module2.json"
    ]
}
```

- :x: Heavy use of symbols makes it unreadable for those used to indentation.
- :x: Strings are not confusing but now are completely unexciting.
- :x: Spec is filled with scary parsing diagrams.
- :x: Terrible name: **J**ava**S**cript **O**bject **N**otation is incredibly boring, uncreative, and worthy of being created by middle-management that does not know what JavaScript actually is.
- :x: Has a suitable amount of commas, but yells at you, if they're not in the right place,.,,
- :x: Has no comments at all, which does not ensure job security, because you can't actually read what you wrote. (json-glib has comments, but those give ugly squiggly lines in your editors, so no one likes those.)
- :x: Well-understood by ChatGPT, which will result in the singularity and destroy sandboxing.
- :heavy_check_mark: Does not hate Norway.

Alas, all hope seems lost...but! I have searched far and wide, and found the perfect language to replace these both: [ESON](https://esolangs.org/wiki/ESON), a stack-based, RPN-style format.

```
"module1 "name (,,)
  "include2/module2.eson
    "module1-first "name (,,)
    "simple "buildsystem (,,)
      "echo%20module1%20>%20/app/modify_me
      "echo%20module1%20>%20/app/ran_module1
      2 [] "build-commands (,,)
        "patch "type (,,)
        0 "strip-components (,,)
        "data1.patch "path (,,)
        3 {:}

        "file "type (,,)
        "data1 "path (,,)
        2 {:}

        2 [] "sources (,,)
    4 {:}
  2 [] "modules (,,)
2 {:}
```

- :heavy_check_mark: Use of heavy symbols in strange places makes it equally unreadable for those used to symbols *and* those used to indentation.
- :heavy_check_mark: Strings follow a simple, readable format (URI-encoding) and require only one delimiter. (No one uses spaces, right?)
- :heavy_check_mark: Spec is so simple that I had to extend it to support flatpak-builder's use cases by adding support for bools. This simplicity is Very Important according to Hacker News commenters, which must be correct because the internet never lies.
- :heavy_check_mark: Excellent name: entirely nonsensical and can be resolved in linear time.
- :heavy_check_mark: Has a suitable amount of commas in consistent places.
- :heavy_check_mark: Lets you push extra values onto the stack at the very beginning to use as comments, thus preserving the ability to read your own code *and* your job security (because none of the text is in the right place).
- :heavy_check_mark: Understood by neither ChatGPT nor other humans, which will result in saving sandboxing from the singularity.
- :heavy_check_mark: Does not hate Norway.

There are numerous other benefits as well, which are apparent if you observe the full `test.eson` from the unit tests:

```
"org.test.Hello2 "app-id (,,)
"org.test.Platform "runtime (,,)
"org.test.Sdk "sdk (,,)
"hello2.sh "command (,,)
"test 1 [] "tags (,,)
0 "token-type (,,)
"--share=network 1 [] "finish-args (,,)
  "-O2%20-g "cflags (,,)
  "-O2%20-g "cxxflags (,,)
    "bar "FOO (,,)
    "1 "V (,,)
    2 {:} "env (,,)
  3 {:} "build-options (,,)
"*.cleanup "/cleanup 2 [] "cleanup (,,)
"touch%20/app/cleaned_up 1 [] "cleanup-commands (,,)
  "root "name (,,)
      "empty "name (,,)
      1 {:}

      "test2 "name (,,)
        "cp%20source[12]%20/app
        "echo%20foo2%20>%20/app/out2
        2 [] "build-commands (,,)
      "simple "buildsystem (,,)
          "include1/source1.json
          "include1/include2/source2.json

          "file "type (,,)
          "app-data "path (,,)
          2 {:}
        3 [] "sources (,,)
      4 {:}

      "test "name (,,)
      "--some-arg 1 [] "config-opts (,,)
        "cp%20org.test.Hello.png%20/app/share/icons/
        "mkdir%20-p%20/app/share/icons/
        "touch%20/app/bin/file.cleanup
        3 [] "post-install (,,)
      "BAR=2 1 [] "make-args (,,)
      "BAR=3 1 [] "make-install-args (,,)
      "echo%20foo%20>%20/app/out 1 [] "build-commands (,,)
          "patch "type (,,)
          "0001-Add-test-logo.patch "path (,,)
          T "use-git (,,)
          3 {:}

          "shell "type (,,)
            "touch%20/app/cleanup/a_file
            "mkdir%20/app/cleanup/
            2 [] "commands (,,)
          2 {:}

          "script "type (,,)
          "hello2.sh "dest-filename (,,)
          "echo%20"Hello%20world2,%20from%20a%20sandbox" 1 [] "commands (,,)
          3 {:}

          "file "type (,,)
          "app-data "path (,,)
          2 {:}

          "file "type (,,)
          "test-configure "path (,,)
          "configure "dest-filename (,,)
          "675a1ac2feec4d4f54e581b4b01bc3cfd2c1cf31aa5963574d31228c8a11b7e7 "sha256 (,,)
          4 {:}
        5 [] "sources (,,)
      7 {:}
    3 [] "modules (,,)
  2 {:}

  "include1/module1.eson

  2 [] "modules (,,)
11 {:}
```

- Hardcoded array and object lengths encourage careful editing of the code, which helps prevent bugs, according to a recent study (with a sample size of 1).
- Reversed keys / values and arrays enhance your ability to read in non-standard directions. This is extremely important if you were to find yourself stranded in a region where gravity does not exist.
- String syntax encourages refactoring into external scripts.
- No need to worry about syntax highlighting, because nothing understands this.

This pull request contains a full implementation of ESON manifests, complete with test cases. I would encourage anyone to try porting their manifests over so they can enjoy the full experience as soon as possible.

## FAQ

### Do we really need another format?

Of course.

### But then there will be so many supported!

No worries, ESON is superior, and everyone will realize this and move off of JSON/YAML shortly.

### This isn't actually spec-compliant, tons of stuff is missing and tuples aren't even tuples

Shhhhhhhhhhhhhhh

### Is there some way to auto-convert my manifests?

Of course not, that would take the fun out of counting the list & dict items by hand.

### The above indentation style looks horrible

What, would you prefer I tried to adopt GNU-style indentation instead? We all know we don't want that.

### What happens if I try to actually expand the YAML acronym?

DO NOT DO THIS NO ONE HAS SURVIVED 