### PR TITLE
workflows/*: bump actions version, fix warnings

### DIFF
--- a/.github/workflows/block-autosquash-commits.yml
+++ b/.github/workflows/block-autosquash-commits.yml
@@ -10,6 +10,6 @@ jobs:
 
     steps:
       - name: Block Autosquash Commits
-        uses: xt0rted/block-autosquash-commits-action@v2.0.0
+        uses: xt0rted/block-autosquash-commits-action@v2.2.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,8 +28,8 @@ jobs:
         libcurl4-gnutls-dev libflatpak-dev libyaml-dev elfutils git patch unzip
     - name: Check out flatpak
       uses: actions/checkout@v3
-      with:
-        submodules: recursive
+    - name: Checkout submodules
+      run: git submodule update --init --recursive
     - name: configure
       # TODO: Enable gtk-doc builds
       run: ./autogen.sh
@@ -57,8 +57,8 @@ jobs:
         libcurl4-gnutls-dev libflatpak-dev libyaml-dev elfutils git patch unzip
     - name: Check out flatpak
       uses: actions/checkout@v3
-      with:
-        submodules: recursive
+    - name: Checkout submodules
+      run: git submodule update --init --recursive
     - name: configure
       # We disable introspection because it fails with clang: https://bugzilla.redhat.com/show_bug.cgi?id=1543295
       run: ./autogen.sh --disable-introspection

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,7 +27,7 @@ jobs:
         libgirepository1.0-dev libappstream-glib-dev libdconf-dev clang socat flatpak \
         libcurl4-gnutls-dev libflatpak-dev libyaml-dev elfutils git patch unzip
     - name: Check out flatpak
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
       with:
         submodules: true
     - name: configure
@@ -56,7 +56,7 @@ jobs:
         libgirepository1.0-dev libappstream-glib-dev libdconf-dev clang flatpak \
         libcurl4-gnutls-dev libflatpak-dev libyaml-dev elfutils git patch unzip
     - name: Check out flatpak
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
       with:
         submodules: true
     - name: configure
@@ -130,7 +130,7 @@ jobs:
           unzip
 
     - name: Check out flatpak-builder
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Configure flatpak-builder
       # TODO: Enable gtk-doc builds
@@ -143,7 +143,7 @@ jobs:
       run: timeout --signal=KILL -v ${TESTS_TIMEOUT}m meson test -C ${BUILDDIR} --verbose
 
     - name: Upload test logs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: failure() || cancelled()
       with:
         name: test logs

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Check out flatpak
       uses: actions/checkout@v3
       with:
-        submodules: true
+        submodules: recursive
     - name: configure
       # TODO: Enable gtk-doc builds
       run: ./autogen.sh
@@ -58,7 +58,7 @@ jobs:
     - name: Check out flatpak
       uses: actions/checkout@v3
       with:
-        submodules: true
+        submodules: recursive
     - name: configure
       # We disable introspection because it fails with clang: https://bugzilla.redhat.com/show_bug.cgi?id=1543295
       run: ./autogen.sh --disable-introspection


### PR DESCRIPTION
## Changes

- [Bump block-autosquash-commits-action to v2.2.0](https://github.com/flatpak/flatpak-builder/commit/07560a8290fe5f32bf09b15e460815223c00b9a8).
- [check.yml: bump actions version](https://github.com/flatpak/flatpak-builder/commit/363768cef94b134136e0c73c48a337761824b70a).
  - Bump the `actions/checkout` version to v3 (To fix the Node 12 deprecation warning shown under Annotations in Actions, the newer version uses Node 16).
  - Bump the `actions/upload-artifact` version to v3 (To fix the Node 12 deprecation warning shown under Annotations in Actions, the newer version uses Node 16).
- [check.yml: move submodules to a separate command](https://github.com/flatpak/flatpak-builder/pull/539/commits/37292e21fac23826f993b09f5668606ef2e871b4).