### PR TITLE
improve editor experience by adding a `title`

### DIFF
--- a/data/flatpak-manifest.schema.json
+++ b/data/flatpak-manifest.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$comment": "https://docs.flatpak.org/en/latest/flatpak-builder-command-reference.html#flatpak-manifest",
-  "title": "Flatpak",
+  "title": "flatpak-builder manifest",
   "$defs": {
     "ignored-prop": {
       "custom": {

--- a/data/flatpak-manifest.schema.json
+++ b/data/flatpak-manifest.schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$comment": "https://docs.flatpak.org/en/latest/flatpak-builder-command-reference.html#flatpak-manifest",
+  "title": "Flatpak",
   "$defs": {
     "ignored-prop": {
       "custom": {


### PR DESCRIPTION
To avoid displaying the entire schema URL.

https://github.com/SchemaStore/schemastore/blob/master/editor-features.md#title-as-an-expected-object-type