### PR TITLE
git-am: add --no-gpg-sign to override config

### DIFF
--- a/src/builder-source-patch.c
+++ b/src/builder-source-patch.c
@@ -256,6 +256,7 @@ patch (GFile      *dir,
     g_ptr_array_add (args, "git");
     g_ptr_array_add (args, "am");
     g_ptr_array_add (args, "--keep-cr");
+    g_ptr_array_add (args, "--no-gpg-sign");
   } else {
     g_ptr_array_add (args, "patch");
   }


### PR DESCRIPTION
Patches applied with `git am` require committing. If `git` is configured to require signing for commits, then this will block flatpak-builder. The argument overrides `commit.gpgsign=true`. (`git config --global commit.gpgsign true`)

I have not tested this myself. Is it possible to test this on an existing set-up?