### PR TITLE
builder-git: trim whitespace from submodule path

### DIFF
--- a/src/builder-git.c
+++ b/src/builder-git.c
@@ -383,6 +383,8 @@ git_mirror_submodules (const char     *repo_location,
           path = g_key_file_get_string (key_file, submodule, "path", error);
           if (path == NULL)
             return FALSE;
+          /* Remove any trailing whitespace */
+          g_strchomp (path);
 
           relative_url = g_key_file_get_string (key_file, submodule, "url", error);
           /* Remove any trailing whitespace */
@@ -782,6 +784,8 @@ git_extract_submodule (const char     *repo_location,
           path = g_key_file_get_string (key_file, submodule, "path", error);
           if (path == NULL)
             return FALSE;
+          /* Remove any trailing whitespace */
+          g_strchomp (path);
 
           relative_url = g_key_file_get_string (key_file, submodule, "url", error);
           absolute_url = make_absolute (repo_location, relative_url, error);


### PR DESCRIPTION
Without this patch https://github.com/nidefawl/daw-deps/blob/master/.gitmodules is not parsed properly causing `tinyspline` to never be checked out because it check for `tinyspline` since there is a whitespace at the end of the `path = `.