### PR TITLE
builder: Fix silent truncation of >32 bit inodes

### DIFF
--- a/src/builder-cache.c
+++ b/src/builder-cache.c
@@ -691,7 +691,7 @@ typedef struct {
 static const char *
 devino_cache_lookup (OstreeRepoDevInoCache *devino_to_csum_cache,
                      guint32               device,
-                     guint32               inode)
+                     guint64               inode)
 {
   OstreeDevIno dev_ino_key;
   OstreeDevIno *dev_ino_val;


### PR DESCRIPTION
See https://github.com/ostreedev/ostree/pull/2874
"commit: fix ostree deployment on 64-bit inode fs"