### PR TITLE
Enable compressed downloads for file sources

### DIFF
--- a/src/builder-utils.c
+++ b/src/builder-utils.c
@@ -1106,6 +1106,7 @@ builder_download_uri_buffer (GUri           *uri,
   g_autofree gchar *url = g_uri_to_string (uri);
 
   curl_easy_setopt (session, CURLOPT_URL, url);
+  curl_easy_setopt (session, CURLOPT_ACCEPT_ENCODING, "");
   curl_easy_setopt (session, CURLOPT_REFERER, http_referer);
   curl_easy_setopt (session, CURLOPT_WRITEFUNCTION, builder_curl_write_cb);
   curl_easy_setopt (session, CURLOPT_WRITEDATA, &write_data);


### PR DESCRIPTION
With this option set, curl will automatically accept and decompress all compressed content types it supports (as of today, brotli, gzip and deflate). Currently, if the website refuses to offer a non-compressed request, flatpak-builder will simply not be able to download it (usually downloading a 403 forbidden page or something).

This is analogous to the `--compressed` flag on the CLI and, as far as I'm concerned, will have no drawback (web servers just ignore it if they don't want to serve compressed files, it is an option and not a request) so I didn't add a configuration key to toggle.