### PR TITLE
Improve handling of a symlinked application directory

### DIFF
--- a/src/builder-cache.c
+++ b/src/builder-cache.c
@@ -309,7 +309,7 @@ builder_cache_checkout (BuilderCache *self, const char *commit, gboolean delete_
 
   if (delete_dir)
     {
-      if (!g_file_delete (self->app_dir, NULL, &my_error) &&
+      if (!flatpak_rm_rf_children (self->app_dir, NULL, &my_error) &&
           !g_error_matches (my_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
         {
           g_propagate_error (error, g_steal_pointer (&my_error));

--- a/src/builder-flatpak-utils.c
+++ b/src/builder-flatpak-utils.c
@@ -980,6 +980,16 @@ flatpak_rm_rf (GFile         *dir,
                                cancellable, error);
 }
 
+gboolean
+flatpak_rm_rf_children (GFile         *dir,
+                        GCancellable  *cancellable,
+                        GError       **error)
+{
+	return glnx_shutil_rm_rf_children_at (AT_FDCWD,
+					      flatpak_file_get_path_cached (dir),
+	                                      cancellable, error);
+}
+
 gboolean flatpak_file_rename (GFile *from,
                               GFile *to,
                               GCancellable  *cancellable,

--- a/src/builder-flatpak-utils.h
+++ b/src/builder-flatpak-utils.h
@@ -237,6 +237,10 @@ gboolean flatpak_rm_rf (GFile         *dir,
                         GCancellable  *cancellable,
                         GError       **error);
 
+gboolean flatpak_rm_rf_children (GFile         *dir,
+                                 GCancellable  *cancellable,
+                                 GError       **error);
+
 static inline void
 flatpak_temp_dir_destroy (void *p)
 {

--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -802,15 +802,14 @@ main (int    argc,
   if (!opt_download_only)
     {
       g_autofree char *state_path = g_file_get_path (builder_context_get_state_dir (build_context));
-      g_autoptr(GFile) app_parent = g_file_get_parent (builder_context_get_app_dir (build_context));
-      g_autofree char *app_parent_path = g_file_get_path (app_parent);
+      g_autofree char *app_path = g_file_get_path (builder_context_get_app_dir (build_context));
       struct stat buf1, buf2;
 
-      if (stat (app_parent_path, &buf1) == 0 && stat (state_path, &buf2) == 0 &&
+      if (stat (app_path, &buf1) == 0 && stat (state_path, &buf2) == 0 &&
           buf1.st_dev != buf2.st_dev)
         {
           g_printerr ("The state dir (%s) is not on the same filesystem as the target dir (%s)\n",
-                      state_path, app_parent_path);
+                      state_path, app_path);
           return 1;
         }
     }

--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -782,7 +782,7 @@ main (int    argc,
           if (opt_force_clean)
             {
               g_print ("Emptying app dir '%s'\n", app_dir_path);
-              if (!flatpak_rm_rf (app_dir, NULL, &error))
+              if (!flatpak_rm_rf_children (app_dir, NULL, &error))
                 {
                   g_printerr ("Couldn't empty app dir '%s': %s\n",
                               app_dir_path, error->message);


### PR DESCRIPTION
Two changes to better handle a case where the application directory is a symlink (e. g. to a faster/larger storage or a scratch location):

- when `--force-clean` is passed, only clear the contents of the application directory, not the dir itself;
- change the same-filesystem check to consider the application directory rather than its parent.

I had to write some new code in libglnx which is tracked in this MR: https://gitlab.gnome.org/GNOME/libglnx/-/merge_requests/49