### PR TITLE
builder-module: Use `meson setup` instead of `meson`

### DIFF
--- a/src/builder-module.c
+++ b/src/builder-module.c
@@ -1775,6 +1775,12 @@ builder_module_build_helper (BuilderModule  *self,
       prefix = builder_options_get_prefix (self->build_options, context);
       libdir = builder_options_get_libdir (self->build_options, context);
 
+      if (meson)
+	{
+	  /* Meson's setup command is now meson setup */
+          g_ptr_array_add (configure_args_arr, g_strdup ("setup"));
+	}
+
       if (cmake || cmake_ninja)
         {
           g_ptr_array_add (configure_args_arr, g_strdup_printf ("-DCMAKE_INSTALL_PREFIX:PATH='%s'", prefix));


### PR DESCRIPTION
Running just `meson` is deprecated and should be replaced with the explicit `meson setup` ([Reference](https://mesonbuild.com/Commands.html#setup))