### PR TITLE
CI: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,7 +27,7 @@ jobs:
         libgirepository1.0-dev libappstream-dev libdconf-dev clang socat flatpak \
         libcurl4-gnutls-dev libflatpak-dev libyaml-dev elfutils git patch unzip
     - name: Check out flatpak
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
       with:
         submodules: true
     - name: configure
@@ -56,7 +56,7 @@ jobs:
         libgirepository1.0-dev libappstream-dev libdconf-dev clang flatpak \
         libcurl4-gnutls-dev libflatpak-dev libyaml-dev elfutils git patch unzip
     - name: Check out flatpak
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
       with:
         submodules: true
     - name: configure
@@ -131,7 +131,7 @@ jobs:
           unzip
 
     - name: Check out flatpak-builder
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Configure flatpak-builder
       # TODO: Enable gtk-doc builds


### PR DESCRIPTION
This PR bumps the actions/checkout version from v3 (Node 16), v2 and v1 to v4 (Node 20) as Node 16 is reaching eol soon and older versions have reached eol.
Ref. https://nodejs.org/en/blog/announcements/nodejs16-eol