### PR TITLE
Set a download speed timeout in the curl session

### DIFF
--- a/src/builder-flatpak-utils.c
+++ b/src/builder-flatpak-utils.c
@@ -1154,6 +1154,8 @@ flatpak_create_curl_session (const char *user_agent)
   curl_easy_setopt (curl_session, CURLOPT_FOLLOWLOCATION, 1);
   curl_easy_setopt (curl_session, CURLOPT_MAXREDIRS, 50);
   curl_easy_setopt (curl_session, CURLOPT_NOPROGRESS, 0);
+  curl_easy_setopt (curl_session, CURLOPT_LOW_SPEED_TIME, 60L);
+  curl_easy_setopt (curl_session, CURLOPT_LOW_SPEED_LIMIT, 10000L);
   curl_easy_setopt (curl_session, CURLOPT_USERAGENT, user_agent);
 
   return curl_session;


### PR DESCRIPTION
This will abort the download if it’s slower than 10KB/sec for 60 seconds with CURLE_OPERATION_TIMEDOUT

The limits are copied from https://github.com/flatpak/flatpak/commit/d6b10c26efd583805ec7085c040a52d0884c305b

This seems it could be useful in CI which may want to proactively kill a pipeline if a download timeouts

I have no idea how to test this, but hopefully it works.

@nanonyme wanted this for Freedesktop SDK CI