### PR TITLE
Add a note that app-id is deprecated

### DIFF
--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -54,7 +54,9 @@
         <variablelist>
                 <varlistentry>
                     <term><option>id</option> or <option>app-id</option> (string)</term>
-                    <listitem><para>A string defining the application id.</para></listitem>
+                    <listitem><para>A string defining the application id.</para>
+                    <para>Note, "app-id" is deprecated and preserved only for
+                    backwards compatibility.</para></listitem>
                 </varlistentry>
                 <varlistentry>
                     <term><option>branch</option> (string)</term>


### PR DESCRIPTION
This was soft deprecated in https://github.com/flatpak/flatpak-builder/commit/3341fb08adc981879043445e8c40883786705738#diff-fe51491bafa983ec48ccdaa2da758238ee9d5623e20cea285cae410d22dd645dR73, https://github.com/flatpak/flatpak-builder/commit/3341fb08adc981879043445e8c40883786705738#diff-fe51491bafa983ec48ccdaa2da758238ee9d5623e20cea285cae410d22dd645dR359-R365 in favour of "id" which aligns with appstream https://github.com/ximion/appstream/commit/8b412031037ea08028279e9408ea0eda01938c48


This achieves nothing other than putting some doubt and confusion to rest in flathub when people open PRs to switch appid -> id and the docs have no mention of it anywhere.


As far as I can tell, this is the primary source and the only place app-id/id is mentioned in the context of a manifest. There are some other minor examples that need to be switched to id in the flatpak-docs repo. I'll handle that. I didn't see app-id being used in the context of manifest in the flatpak repo.