### PR TITLE
Add support for 'autoprune-unless' for extensions

### DIFF
--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -471,7 +471,7 @@
               Additionally the standard flatpak extension properties
               are supported, and put directly into the metadata file:
               autodelete, no-autodownload, subdirectories,
-              add-ld-path, download-if, enable-if, merge-dirs,
+              add-ld-path, download-if, enable-if, autoprune-unless, merge-dirs,
               subdirectory-suffix, locale-subset, version, versions.
               See the flatpak metadata documentation for more information on these.
             </para>

--- a/src/builder-extension.c
+++ b/src/builder-extension.c
@@ -49,6 +49,7 @@ struct BuilderExtension
   char           *add_ld_path;
   char           *download_if;
   char           *enable_if;
+  char           *autoprune_unless;
   char           *merge_dirs;
   char           *subdirectory_suffix;
   char           *version;
@@ -71,6 +72,7 @@ enum {
   PROP_ADD_LD_PATH,
   PROP_DOWNLOAD_IF,
   PROP_ENABLE_IF,
+  PROP_AUTOPRUNE_UNLESS,
   PROP_MERGE_DIRS,
   PROP_NO_AUTODOWNLOAD,
   PROP_LOCALE_SUBSET,
@@ -92,6 +94,7 @@ builder_extension_finalize (GObject *object)
   g_free (self->add_ld_path);
   g_free (self->download_if);
   g_free (self->enable_if);
+  g_free (self->autoprune_unless);
   g_free (self->merge_dirs);
   g_free (self->subdirectory_suffix);
   g_free (self->version);
@@ -148,6 +151,10 @@ builder_extension_get_property (GObject    *object,
 
     case PROP_ENABLE_IF:
       g_value_set_string (value, self->enable_if);
+      break;
+
+    case PROP_AUTOPRUNE_UNLESS:
+      g_value_set_string (value, self->autoprune_unless);
       break;
 
     case PROP_MERGE_DIRS:
@@ -223,6 +230,11 @@ builder_extension_set_property (GObject      *object,
     case PROP_ENABLE_IF:
       g_clear_pointer (&self->enable_if, g_free);
       self->enable_if = g_value_dup_string (value);
+      break;
+
+  case PROP_AUTOPRUNE_UNLESS:
+      g_clear_pointer (&self->autoprune_unless, g_free);
+      self->autoprune_unless = g_value_dup_string (value);
       break;
 
     case PROP_MERGE_DIRS:
@@ -325,6 +337,13 @@ builder_extension_class_init (BuilderExtensionClass *klass)
   g_object_class_install_property (object_class,
                                    PROP_ENABLE_IF,
                                    g_param_spec_string ("enable-if",
+                                                        "",
+                                                        "",
+                                                        NULL,
+                                                        G_PARAM_READWRITE));
+  g_object_class_install_property (object_class,
+                                   PROP_AUTOPRUNE_UNLESS,
+                                   g_param_spec_string ("autoprune-unless",
                                                         "",
                                                         "",
                                                         NULL,
@@ -445,6 +464,7 @@ builder_extension_add_finish_args (BuilderExtension  *self,
   add_arg (self, args, FLATPAK_METADATA_KEY_ADD_LD_PATH, self->add_ld_path);
   add_arg (self, args, FLATPAK_METADATA_KEY_DOWNLOAD_IF, self->download_if);
   add_arg (self, args, FLATPAK_METADATA_KEY_ENABLE_IF, self->enable_if);
+  add_arg (self, args, FLATPAK_METADATA_KEY_AUTOPRUNE_UNLESS, self->autoprune_unless);
   add_arg (self, args, FLATPAK_METADATA_KEY_MERGE_DIRS, self->merge_dirs);
   add_arg (self, args, FLATPAK_METADATA_KEY_SUBDIRECTORY_SUFFIX, self->subdirectory_suffix);
   add_arg (self, args, FLATPAK_METADATA_KEY_VERSION, self->version);
@@ -467,6 +487,7 @@ builder_extension_checksum (BuilderExtension  *self,
   builder_cache_checksum_str (cache, self->add_ld_path);
   builder_cache_checksum_str (cache, self->download_if);
   builder_cache_checksum_str (cache, self->enable_if);
+  builder_cache_checksum_str (cache, self->autoprune_unless);
   builder_cache_checksum_str (cache, self->merge_dirs);
   builder_cache_checksum_str (cache, self->subdirectory_suffix);
   builder_cache_checksum_str (cache, self->version);

--- a/src/builder-flatpak-utils.h
+++ b/src/builder-flatpak-utils.h
@@ -45,6 +45,7 @@ typedef void (*FlatpakLoadUriProgress) (guint64 downloaded_bytes,
 #define FLATPAK_METADATA_KEY_DIRECTORY "directory"
 #define FLATPAK_METADATA_KEY_DOWNLOAD_IF "download-if"
 #define FLATPAK_METADATA_KEY_ENABLE_IF "enable-if"
+#define FLATPAK_METADATA_KEY_AUTOPRUNE_UNLESS "autoprune-unless"
 #define FLATPAK_METADATA_KEY_MERGE_DIRS "merge-dirs"
 #define FLATPAK_METADATA_KEY_NO_AUTODOWNLOAD "no-autodownload"
 #define FLATPAK_METADATA_KEY_LOCALE_SUBSET "locale-subset"


### PR DESCRIPTION
This is an existing flatpak feature that was never added to flatpak-builder, so it couldn't be used in app manifests.

I've simply duplicated the code for `enable-if` and changed the name. That was enough to get `autoprune-unless` to pass through from the manifest to the app metadata.

To help address https://github.com/flatpak/flatpak/issues/2718, I looked into why `flatpak uninstall --unused` removes 64bit nvidia drivers, but not 32bit. I discovered that the `org.freedesktop.Platform.GL` extension point was defined with `autoprune-unless=active-gl-driver`, but `org.freedesktop.Platform.GL32` was not, and that the latter is defined in each app that requires it, rather than in the runtime.

With this in place, as long as all apps that define the extension point use `autoprune-unless=active-gl-driver`, the GL32 extension should be removed just like the GL extension. I've only tested on my non-nvidia system, but it does seem to work as expected.

Steam is actually already using `autoprune-unless` in its manifest, but it's currently being ignored.