### PR TITLE
Remove compressed downloads

### DIFF
--- a/src/builder-utils.c
+++ b/src/builder-utils.c
@@ -1108,7 +1108,6 @@ builder_download_uri_buffer (GUri           *uri,
   g_autofree gchar *url = g_uri_to_string (uri);
 
   curl_easy_setopt (session, CURLOPT_URL, url);
-  curl_easy_setopt (session, CURLOPT_ACCEPT_ENCODING, "");
   curl_easy_setopt (session, CURLOPT_REFERER, http_referer);
   curl_easy_setopt (session, CURLOPT_WRITEFUNCTION, builder_curl_write_cb);
   curl_easy_setopt (session, CURLOPT_WRITEDATA, &write_data);


### PR DESCRIPTION
I found an issue were tar.gz archives were decompressed and caused issues for flatpak-builder

I am not a very technical person so I will try to explain it the best I can with examples.
I was trying to troubleshoot an issue with the package [com.viber.Viber](https://github.com/flathub/com.viber.Viber). Which tries to pull the archive file that is gunzip compressed tar.

however when attempting to decompress it it fails because it is not a gunzip package.
```
FB: Running: tar xf /home/john/Git/com.viber.Viber/.flatpak-builder/downloads/07e20ca8708888592c5160a0cd7c65f3fba1ce2f4dbe635815c0aea6e1dc12aa/krb5-1.20.2.tar.gz --no-same-owner --strip-components=1 -z

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
Error: module krb5: Child process exited with code 2
FB: Unmounting read-only fs: fusermount -uz /home/john/Git/com.viber.Viber/.flatpak-builder/rofiles/rofiles-D1o2mv
```

that is because krb5.tar.gz has been decompressed and is now a simple posix tar archive file with the same name:
```
file .flatpak-builder/downloads/07e20ca8708888592c5160a0cd7c65f3fba1ce2f4dbe635815c0aea6e1dc12aa/krb5-1.20.2.tar.gz 
.flatpak-builder/downloads/07e20ca8708888592c5160a0cd7c65f3fba1ce2f4dbe635815c0aea6e1dc12aa/krb5-1.20.2.tar.gz: POSIX tar archive (GNU)
```
you can also tell by the size being 42MB compared to 8.3MB(which is the normal size)

Removing this line fixes the issue.