### PR TITLE
Default libdir for app is /app/lib

### DIFF
--- a/src/builder-options.c
+++ b/src/builder-options.c
@@ -1075,6 +1075,8 @@ builder_options_get_libdir (BuilderOptions *self, BuilderContext *context)
 
   if (builder_context_get_build_runtime (context))
     return get_sdk_flags (self, context, builder_sdk_config_get_libdir);
+  if (!builder_context_get_build_extension (context))
+    return "/app/lib";
 
   return NULL;
 }


### PR DESCRIPTION
flatpak-builder promises that libdir is /app/lib for apps but this is currently not really the case. Instead, flatpak-builder relies on patching of libdir on Meson and cmake and prefix being set to /app. Since it's not really up to runtime to select what libdir for apps is (this is defined in flatpak instead), instead add a default here.