### PR TITLE
Always calculate libdir

### DIFF
--- a/src/builder-module.c
+++ b/src/builder-module.c
@@ -1787,6 +1787,8 @@ builder_module_build_helper (BuilderModule  *self,
           g_ptr_array_add (configure_args_arr, g_strdup_printf ("-DCMAKE_INSTALL_PREFIX:PATH='%s'", prefix));
           if (libdir)
             g_ptr_array_add (configure_args_arr, g_strdup_printf ("-DCMAKE_INSTALL_LIBDIR:PATH='%s'", libdir));
+          else
+            g_ptr_array_add (configure_args_arr, g_strdup_printf ("-DCMAKE_INSTALL_LIBDIR:PATH='%s/lib'", prefix));
           g_ptr_array_add (configure_args_arr, g_strdup ("-G"));
           g_ptr_array_add (configure_args_arr, g_strdup_printf ("%s", cmake_generator));
         }
@@ -1800,6 +1802,8 @@ builder_module_build_helper (BuilderModule  *self,
           g_ptr_array_add (configure_args_arr, g_strdup_printf ("--prefix=%s", prefix));
           if (libdir)
             g_ptr_array_add (configure_args_arr, g_strdup_printf ("--libdir=%s", libdir));
+          else
+            g_ptr_array_add (configure_args_arr, g_strdup_printf ("--libdir=%s/lib", prefix));
         }
 
       g_ptr_array_add (configure_args_arr, configure_final_arg);

--- a/tests/test-configure
+++ b/tests/test-configure
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-if [ x$2 != 'x--some-arg' ] ; then
+if [ x$3 != 'x--some-arg' ] ; then
+        echo $*
 	exit 2
 fi
 

--- a/tests/test-rename-appdata.json
+++ b/tests/test-rename-appdata.json
@@ -55,7 +55,7 @@
                             "type": "file",
                             "path": "test-configure",
                             "dest-filename": "configure",
-                            "sha256": "675a1ac2feec4d4f54e581b4b01bc3cfd2c1cf31aa5963574d31228c8a11b7e7"
+                            "sha256": "2c661bff6567f0e26e3a4bc5548f5a81ff86e052ccaa3791b847201be84f932f"
                         },
                         {
                             "type": "file",

--- a/tests/test-rename.json
+++ b/tests/test-rename.json
@@ -56,7 +56,7 @@
                             "type": "file",
                             "path": "test-configure",
                             "dest-filename": "configure",
-                            "sha256": "675a1ac2feec4d4f54e581b4b01bc3cfd2c1cf31aa5963574d31228c8a11b7e7"
+                            "sha256": "2c661bff6567f0e26e3a4bc5548f5a81ff86e052ccaa3791b847201be84f932f"
                         },
                         {
                             "type": "file",

--- a/tests/test.json
+++ b/tests/test.json
@@ -48,7 +48,7 @@
                             "type": "file",
                             "path": "test-configure",
                             "dest-filename": "configure",
-                            "sha256": "675a1ac2feec4d4f54e581b4b01bc3cfd2c1cf31aa5963574d31228c8a11b7e7"
+                            "sha256": "2c661bff6567f0e26e3a4bc5548f5a81ff86e052ccaa3791b847201be84f932f"
                         },
                         {
                             "type": "file",

--- a/tests/test.yaml
+++ b/tests/test.yaml
@@ -40,7 +40,7 @@ modules:
           - type: file
             path: test-configure
             dest-filename: configure
-            sha256: 675a1ac2feec4d4f54e581b4b01bc3cfd2c1cf31aa5963574d31228c8a11b7e7
+            sha256: 2c661bff6567f0e26e3a4bc5548f5a81ff86e052ccaa3791b847201be84f932f
           - type: file
             path: app-data
           - type: script


### PR DESCRIPTION
flatpak-builder relies on patched cmake and meson from
freedesktop-sdk to change libdir from lib64 to lib on 64bit
distributions. This dependency is *weird* since it's actually
flatpak that sets up the dynamic linker paths. Instead, put
responsibility for setting up correct libdir to flatpak-builder
always.