### PR TITLE
Move locale migration after cleanup

### DIFF
--- a/src/builder-manifest.c
+++ b/src/builder-manifest.c
@@ -2761,6 +2761,22 @@ builder_manifest_cleanup (BuilderManifest *self,
             }
         }
 
+      if (builder_context_get_separate_locales (context))
+      {
+        g_autoptr(GFile) root_dir = NULL;
+
+        if (builder_context_get_build_runtime (context))
+          root_dir = g_file_get_child (app_dir, "usr");
+        else
+          root_dir = g_file_get_child (app_dir, "files");
+
+        if (!builder_migrate_locale_dirs (root_dir, error))
+          {
+            g_prefix_error (error, "Can't migrate locale dirs: ");
+            return FALSE;
+          }
+      }
+
       app_root = g_file_get_child (app_dir, "files");
 
       appdata_source = builder_manifest_find_appdata_file (self, app_root);

--- a/src/builder-module.c
+++ b/src/builder-module.c
@@ -1916,22 +1916,6 @@ builder_module_build_helper (BuilderModule  *self,
 
   builder_set_term_title (_("Post-Install %s"), self->name);
 
-  if (builder_context_get_separate_locales (context))
-    {
-      g_autoptr(GFile) root_dir = NULL;
-
-      if (builder_context_get_build_runtime (context))
-        root_dir = g_file_get_child (app_dir, "usr");
-      else
-        root_dir = g_file_get_child (app_dir, "files");
-
-      if (!builder_migrate_locale_dirs (root_dir, error))
-        {
-          g_prefix_error (error, "module %s: ", self->name);
-          return FALSE;
-        }
-    }
-
   if (self->post_install)
     {
       for (i = 0; self->post_install[i] != NULL; i++)


### PR DESCRIPTION
Otherwise, module-level cleanup can remove locale symlinks that point to locale data installed by other modules.

Closes #154

I've tested this building an app, and for that at least, it seems to work. I haven't tried building a runtime though. There are two other calls to `builder_migrate_locale_dirs()` that I haven't really investigated. One happens in init for all runtimes, and the other applies only to platforms.