### PR TITLE
builder-module: Fix cmake libdir value

### DIFF
--- a/src/builder-module.c
+++ b/src/builder-module.c
@@ -1788,7 +1788,7 @@ builder_module_build_helper (BuilderModule  *self,
           if (libdir)
             g_ptr_array_add (configure_args_arr, g_strdup_printf ("-DCMAKE_INSTALL_LIBDIR:PATH='%s'", libdir));
           else
-            g_ptr_array_add (configure_args_arr, g_strdup_printf ("-DCMAKE_INSTALL_LIBDIR:PATH='%s/lib'", prefix));
+            g_ptr_array_add (configure_args_arr, g_strdup_printf ("-DCMAKE_INSTALL_LIBDIR:PATH='lib'"));
           g_ptr_array_add (configure_args_arr, g_strdup ("-G"));
           g_ptr_array_add (configure_args_arr, g_strdup_printf ("%s", cmake_generator));
         }


### PR DESCRIPTION
Fixes 8c036e00630e35423c03388aacc06cd00dda74ea

It is being set to `$prefix/lib` but CMAKE_INSTALL_LIBDIR is not an absolute path by convention [1]:

> It should be a path relative to the installation prefix

When it is set to `/app/lib`, it is causing issues in applications [2]

[1]: https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html#result-variables

[2]: https://github.com/flathub/io.github.martinrotter.rssguard/issues/73#issuecomment-2208189029