### PR TITLE
docs: Mention nested modules don't inherit `build-options`

### DIFF
--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -569,7 +569,7 @@
                 </varlistentry>
                 <varlistentry>
                     <term><option>build-options</option> (object)</term>
-                    <listitem><para>A build options object that can override global options</para></listitem>
+                    <listitem><para>A build options object that can override global options. Note that this is not inherited by nested modules.</para></listitem>
                 </varlistentry>
                 <varlistentry>
                     <term><option>build-commands</option> (array of strings)</term>


### PR DESCRIPTION
I think it makes sense to explicitly mention this since it's kinda counterintuitive to what one might expect.