### PR TITLE
Enable authenticated downloads via netrc file

### DIFF
--- a/src/builder-utils.c
+++ b/src/builder-utils.c
@@ -1113,6 +1113,7 @@ builder_download_uri_buffer (GUri           *uri,
   curl_easy_setopt (session, CURLOPT_WRITEFUNCTION, builder_curl_write_cb);
   curl_easy_setopt (session, CURLOPT_WRITEDATA, &write_data);
   curl_easy_setopt (session, CURLOPT_ERRORBUFFER, error_buffer);
+  curl_easy_setopt (session, CURLOPT_NETRC, CURL_NETRC_OPTIONAL);
 
   if (!disable_http_decompression)
     curl_easy_setopt (session, CURLOPT_ACCEPT_ENCODING, "");


### PR DESCRIPTION
Sometimes source archives are only accessible to logged-in users, for example as described in issue #456. However, authentication currently is not supported by flatpak-builder aside from hard-coding credentials in the manifest file.

Since flatpak-builder uses libcurl to download sources we can make use of cURL's support for netrc files to provide credentials out-of-band. While that does not directly solve #456 it offers an in my opinion superior alternative: Instead of hard-coding username and password in the manifest file the reporter of #456 can now create the file `~/.netrc` with the following content:

```
machine gitlab.com
  login <user>
  password <password>
```

This allows storing the manifest file in version control without exposing the credentials to all other developers.