### PR TITLE
builder-main: Commit mirrored media as screenshot ref to exported repo

### DIFF
--- a/doc/flatpak-builder.xml
+++ b/doc/flatpak-builder.xml
@@ -528,7 +528,9 @@
                   in the appstream xml to the specified URL. The resulting files
                   will be stored in the "screenshots" subdirectory in the app directory
                   for versions earlier than 1.3.4 and "files/share/app-info/media"
-                  subdirectory for newer versions.
+                  subdirectory for newer versions. Since version 1.4.5 this
+                  will also create a screenshot ref in the exported OSTree
+                  repo for each architecture containing the mirrored media.
                 </para></listitem>
             </varlistentry>
 

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -58,6 +58,9 @@ dist_installed_test_data = \
 	tests/org.test.Deprecated.SHA1.file.yaml \
 	tests/hello.sh \
 	tests/hello.tar.xz \
+	tests/org.flatpak_builder.gui.desktop \
+	tests/org.flatpak_builder.gui.json \
+	tests/org.flatpak_builder.gui.metainfo.xml \
 	$(NULL)
 
 installed_test_keyringdir = $(installed_testdir)/test-keyring

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -105,6 +105,9 @@ if get_option('installed_tests')
     'test-runtime.json',
     'test.json',
     'test.yaml',
+    'tests/org.flatpak_builder.gui.desktop',
+    'tests/org.flatpak_builder.gui.json',
+    'tests/org.flatpak_builder.gui.metainfo.xml',
 
     install_dir: installed_testdir,
     install_mode: 'rw-r--r--',

--- a/tests/org.flatpak_builder.gui.desktop
+++ b/tests/org.flatpak_builder.gui.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Example
+GenericName=Example
+Comment=Example
+Exec=hello %U
+Icon=org.flatpak_builder.gui
+Type=Application
+Categories=Network;
+Version=1.1

--- a/tests/org.flatpak_builder.gui.json
+++ b/tests/org.flatpak_builder.gui.json
@@ -1,0 +1,41 @@
+{
+    "id": "org.flatpak_builder.gui",
+    "runtime": "org.test.Platform",
+    "sdk": "org.test.Sdk",
+    "command": "hello",
+    "modules": [
+        {
+            "name": "hello_gui",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p ${FLATPAK_DEST}/bin ${FLATPAK_DEST}/share/metainfo ${FLATPAK_DEST}/share/applications",
+                "mkdir -p ${FLATPAK_DEST}/share/icons/hicolor/64x64/apps",
+                "cp -vf hello.sh ${FLATPAK_DEST}/bin/hello",
+                "cp -vf ${FLATPAK_ID}.metainfo.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml",
+                "cp -vf ${FLATPAK_ID}.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop",
+                "cp -vf org.test.Hello.png ${FLATPAK_DEST}/share/icons/hicolor/64x64/apps/${FLATPAK_ID}.png"
+            ],
+            "sources": [
+                {
+                    "type": "script",
+                    "dest-filename": "hello.sh",
+                    "commands": [
+                        "echo \"Hello world, from a sandbox\""
+                    ]
+                },
+                {
+                    "type": "file",
+                    "path": "org.flatpak_builder.gui.desktop"
+                },
+                {
+                    "type": "file",
+                    "path": "org.flatpak_builder.gui.metainfo.xml"
+                },
+                {
+                    "type": "file",
+                    "path": "org.test.Hello.png"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/org.flatpak_builder.gui.metainfo.xml
+++ b/tests/org.flatpak_builder.gui.metainfo.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>org.flatpak_builder.gui</id>
+  <launchable type="desktop-id">org.flatpak_builder.gui.desktop</launchable>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0+</project_license>
+  <name>org.flatpak_builder.gui</name>
+  <developer_name>Flatpak</developer_name>
+  <summary>Foo foo foo foo</summary>
+  <url type="homepage">https://flatpak.org</url>
+  <description>
+    <p>An example desktop application</p>
+  </description>
+  <screenshots>
+    <!-- appstream silently continues without error if the file fails to
+         download. since the tag only accepts http(s) urls, we add
+         multiple sources so that in case one link fails, at least one
+         of the other ones work. Replace with any other screenshot
+         link if it fails
+     -->
+    <screenshot type="default">
+      <caption>An example screenshot</caption>
+      <image>https://raw.githubusercontent.com/flatpak/flatpak.github.io/0b56895e271bbcc7f86f9570933a96adff99e110/source/img/endless-apps.original.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>An example screenshot</caption>
+      <image>https://docs.flathub.org/img/card.png</image>
+    </screenshot>
+  </screenshots>
+  <url type="bugtracker">https://flatpak.org</url>
+  <content_rating type="oars-1.1"/>
+  <releases>
+    <release version="0.0.1" date="2020-08-28"/>
+  </releases>
+</component>

--- a/tests/test-builder.sh
+++ b/tests/test-builder.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 
 skip_without_fuse
 
-echo "1..7"
+echo "1..8"
 
 setup_repo
 install_repo
@@ -49,6 +49,10 @@ cp $(dirname $0)/Hello-desktop.appdata.xml .
 cp $(dirname $0)/org.test.Hello.desktop .
 cp $(dirname $0)/org.test.Hello.xml .
 cp $(dirname $0)/org.test.Hello.appdata.xml .
+cp $(dirname $0)/org.flatpak_builder.gui.desktop .
+cp $(dirname $0)/org.flatpak_builder.gui.json .
+cp $(dirname $0)/org.flatpak_builder.gui.metainfo.xml .
+cp $(dirname $0)/org.test.Hello.png .
 mkdir include1
 cp $(dirname $0)/module1.json include1/
 cp $(dirname $0)/module1.yaml include1/
@@ -127,3 +131,13 @@ ${FLATPAK_BUILDER} $FL_GPGARGS --repo=$REPO --force-clean runtimedir \
     test-runtime.json >&2
 
 echo "ok runtime build cleanup with build-args"
+
+# test screenshot ref commit
+${FLATPAK_BUILDER} --repo=$REPO/repo_sc --force-clean builddir_sc \
+    --mirror-screenshots-url=https://example.org/media \
+    org.flatpak_builder.gui.json >&2
+ostree --repo=$REPO/repo_sc refs|grep -Eq "^screenshots/$(flatpak --default-arch)$"
+ostree checkout --repo=$REPO/repo_sc -U screenshots/$(flatpak --default-arch) outdir_sc
+find outdir_sc -path "*/screenshots/image-1_orig.png" -type f | grep -q .
+
+echo "ok screenshot ref commit"


### PR DESCRIPTION
```
This is needed to store the application icons and the mirrored
screenshots (as done by appstream) to the ostree repo. This can be
useful in many ways, the primary being flat-manager extracts [1] these
screenshot refs and stores them in the server so that application
store frontends can use their own mirrored screenshot and icon URLs.

This has been for the longest time done at various downstream levels
such as in buildbot [2], flatpak-github-actions [3] and vorarbeiter [4]
(the successor to buildbot) but it's more user friendly to have
flatpak-builder do this extra work.

[1]: https://github.com/flatpak/flat-manager/commit/eff43004756c011b0a0d034a61cec84836b8e0a9
[2]: https://github.com/flathub-infra/buildbot/blob/9d8e2b5483b2e446389548446ebf9c3934380682/master/buildbot/flathub_master.py#L1081
[3]: https://github.com/flatpak/flatpak-github-actions/blob/6684584b07d86113b1acfc80b3e4667f16f617c3/flatpak-builder/index.js#L280-L286
[4]: https://github.com/flathub-infra/vorarbeiter/blob/7f2f04a562e73ba4f46044dae7c99f8e9e64a39d/justfile#L185-L189
```