### PR TITLE
builder-source-archive: Switch to bsdunzip

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,7 +25,7 @@ jobs:
         libjson-glib-dev shared-mime-info desktop-file-utils libpolkit-agent-1-dev libpolkit-gobject-1-dev \
         libseccomp-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
         libgirepository1.0-dev libappstream-dev libdconf-dev clang socat flatpak \
-        libcurl4-gnutls-dev libflatpak-dev libyaml-dev elfutils git patch unzip
+        libcurl4-gnutls-dev libflatpak-dev libyaml-dev elfutils git patch libarchive-tools
     - name: Check out flatpak
       uses: actions/checkout@v4
       with:
@@ -58,7 +58,7 @@ jobs:
         libjson-glib-dev shared-mime-info desktop-file-utils libpolkit-agent-1-dev libpolkit-gobject-1-dev \
         libseccomp-dev libsystemd-dev libxml2-utils libgpgme11-dev gobject-introspection \
         libgirepository1.0-dev libappstream-dev libdconf-dev clang flatpak \
-        libcurl4-gnutls-dev libflatpak-dev libyaml-dev elfutils git patch unzip
+        libcurl4-gnutls-dev libflatpak-dev libyaml-dev elfutils git patch libarchive-tools
     - name: Check out flatpak
       uses: actions/checkout@v4
       with:
@@ -132,7 +132,7 @@ jobs:
           patch \
           shared-mime-info \
           socat \
-          unzip
+          libarchive-tools
 
     - name: Check out flatpak-builder
       uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Very commonly used:
  * cp
  * git
  * 7z
- * unzip
+ * bsdunzip (libarchive)
 
 Rarely used:
 

--- a/ci/libbuild.sh
+++ b/ci/libbuild.sh
@@ -50,7 +50,7 @@ pkg_install_builddeps() {
     else
         yum -y install yum-utils
         # Base buildroot, copied from the mock config sadly
-        yum -y install bash bzip2 coreutils cpio diffutils system-release findutils gawk gcc gcc-c++ grep gzip info make patch redhat-rpm-config rpm-build sed shadow-utils tar unzip util-linux which xz
+        yum -y install bash bzip2 coreutils cpio diffutils system-release findutils gawk gcc gcc-c++ grep gzip info make patch redhat-rpm-config rpm-build sed shadow-utils tar libarchive-tools util-linux which xz
     fi
     # builddeps+runtime deps
     pkg_builddep $pkg

--- a/src/builder-source-archive.c
+++ b/src/builder-source-archive.c
@@ -507,7 +507,7 @@ unzip (GFile       *dir,
        GError     **error)
 {
   gboolean res;
-  const char *argv[] = { "unzip", "-q", zip_path, NULL };
+  const char *argv[] = { "bsdunzip", "-q", zip_path, NULL };
 
   res = flatpak_spawnv (dir, NULL, 0, error, argv, NULL);
 


### PR DESCRIPTION
info-zip's unzip is unmaintained and horribly behind security patches so switch to bsdunzip from libarchive.

See https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/687b07205c02d28622053d419ec0f3c6f0240f5b/elements/components/unzip.bst#L45-68 and https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/issues/1777