### PR TITLE
ci: Don't run apt upgrade

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -89,7 +89,6 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt-get update
-        sudo apt-get upgrade -y
         sudo apt-get install -y \
           ${{ matrix.compiler }} \
           attr \


### PR DESCRIPTION
This tries to upgrade firefox to a snap package and wastes time downloading MBs...

https://github.com/flatpak/flatpak-builder/actions/runs/17385865788/job/49352696434?pr=655#step:2:142