### PR TITLE
builder-source-archive: Explicitly commit with no-gpg-sign

### DIFF
--- a/src/builder-source-archive.c
+++ b/src/builder-source-archive.c
@@ -703,7 +703,7 @@ init_git (GFile   *dir,
   basename = g_file_get_basename (dir);
   if (!git (dir, error, "init", NULL) ||
       !git (dir, error, "add", "--ignore-errors", ".", NULL) ||
-      !git (dir, error, "commit", "-m", basename, NULL))
+      !git (dir, error, "commit", "--no-gpg-sign", "-m", basename, NULL))
     {
       g_free (basename);
       return FALSE;


### PR DESCRIPTION
Fixes https://github.com/flatpak/flatpak-builder/issues/439

It does not make much sense trying to commit inside the state dir with gpg signing enabled. It should be as non interactive as possible otherwise, it will just hang