### PR TITLE
tests: Allow screenshot ref commit test to run offline

### DIFF
--- a/tests/org.flatpak_builder.gui.json
+++ b/tests/org.flatpak_builder.gui.json
@@ -3,17 +3,15 @@
     "runtime": "org.test.Platform",
     "sdk": "org.test.Sdk",
     "command": "hello",
+    "appstream-compose": false,
     "modules": [
         {
             "name": "hello_gui",
             "buildsystem": "simple",
             "build-commands": [
-                "mkdir -p ${FLATPAK_DEST}/bin ${FLATPAK_DEST}/share/metainfo ${FLATPAK_DEST}/share/applications",
-                "mkdir -p ${FLATPAK_DEST}/share/icons/hicolor/64x64/apps",
+                "mkdir -p ${FLATPAK_DEST}/bin",
                 "cp -vf hello.sh ${FLATPAK_DEST}/bin/hello",
-                "cp -vf ${FLATPAK_ID}.metainfo.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml",
-                "cp -vf ${FLATPAK_ID}.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop",
-                "cp -vf org.test.Hello.png ${FLATPAK_DEST}/share/icons/hicolor/64x64/apps/${FLATPAK_ID}.png"
+                "DIR=\"${FLATPAK_DEST}/share/app-info/media/org/flatpak_builder/gui/foobar/icons/64x64\" && mkdir -p \"$DIR\" && cp -vf org.test.Hello.png \"$DIR\""
             ],
             "sources": [
                 {
@@ -22,14 +20,6 @@
                     "commands": [
                         "echo \"Hello world, from a sandbox\""
                     ]
-                },
-                {
-                    "type": "file",
-                    "path": "org.flatpak_builder.gui.desktop"
-                },
-                {
-                    "type": "file",
-                    "path": "org.flatpak_builder.gui.metainfo.xml"
                 },
                 {
                     "type": "file",

--- a/tests/test-builder.sh
+++ b/tests/test-builder.sh
@@ -141,6 +141,6 @@ ${FLATPAK_BUILDER} --repo=$REPO/repo_sc --force-clean builddir_sc \
     org.flatpak_builder.gui.json >&2
 ostree --repo=$REPO/repo_sc refs|grep -Eq "^screenshots/$(flatpak --default-arch)$"
 ostree checkout --repo=$REPO/repo_sc -U screenshots/$(flatpak --default-arch) outdir_sc
-find outdir_sc -path "*/screenshots/image-1_orig.png" -type f | grep -q .
+find outdir_sc -path "*/icons/64x64/org.test.Hello.png" -type f | grep -q .
 
 echo "ok screenshot ref commit"


### PR DESCRIPTION
This makes it harder for me to write the test for https://github.com/flatpak/flatpak-builder/pull/652, but if offline tests are wanted, so be it.

I didn't delete the test files, as I plan to reuse them later for the test in #652. I need some fully qualified and valid desktop file, metainfo file for that.