### PR TITLE
builder-main: Always update appstream branches when exporting to repo

### DIFF
--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -219,6 +219,8 @@ do_export (BuilderContext *build_context,
 
   g_ptr_array_add (args, g_strdup_printf ("--arch=%s", builder_context_get_arch (build_context)));
 
+  g_ptr_array_add (args, g_strdup ("--update-appstream"));
+
   if (runtime)
     g_ptr_array_add (args, g_strdup ("--runtime"));
 


### PR DESCRIPTION
This creates or updates the appstream and appstream2 refs to the exported repo. The appstream refs are needed to display appstream information (version, name etc.) if the exported repo is being used as a remote.

If `files/share/app-info` does not exist inside the build for example for extensions etc. flatpak build-export simply continues by printing a line.

Fixes https://github.com/flatpak/flatpak-builder/issues/376