### PR TITLE
builder-module: Create a fixed alias for builddir of current module

### DIFF
--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -1024,7 +1024,8 @@
           <filename>build/$modulename-$count</filename> in the state dir (which is typically <filename>.flatpak-builder/</filename>).
           Additionally there is a symlink <filename>build/$modulename</filename> to the latest version.
           In order to generate reproducible builds this directory is also mounted as <filename>/run/build/$modulename</filename>
-          in the sandbox (or <filename>/run/build-runtime/$modulename</filename> when building runtimes).
+          in the sandbox (or <filename>/run/build-runtime/$modulename</filename> when building runtimes) and also as
+          <filename>/run/active-build</filename> since 1.4.7.
           This is used as current working directory for all build ops.
         </para>
         <para>

--- a/src/builder-module.c
+++ b/src/builder-module.c
@@ -1256,6 +1256,8 @@ setup_build_args (GFile          *app_dir,
     g_ptr_array_add (args, g_strdup_printf ("--bind-mount=%s=%s", source_dir_path, source_dir_path_canonical));
 
   g_ptr_array_add (args, g_strdup_printf ("--bind-mount=%s%s=%s", builddir, module_name, source_dir_path_canonical));
+  g_ptr_array_add (args, g_strdup_printf ("--bind-mount=/run/active-build=%s", source_dir_path_canonical));
+
   if (cwd_subdir)
     g_ptr_array_add (args, g_strdup_printf ("--build-dir=%s%s/%s", builddir, module_name, cwd_subdir));
   else


### PR DESCRIPTION
We create the path at `/run` as any subdir name inside `/run/build` may be taken over by an actual module name.

Fixes https://github.com/flatpak/flatpak-builder/issues/488