### PR TITLE
builder-manifest: Fix an uninitialised variable warning

### DIFF
--- a/src/builder-manifest.c
+++ b/src/builder-manifest.c
@@ -2343,7 +2343,7 @@ _rename_icon (ForeachFile     *self,
            g_str_has_prefix (source_name + strlen (self->rename_icon), "-symbolic.")))
         {
           const char *extension = source_name + strlen (self->rename_icon);
-          g_autofree char *new_name;
+          g_autofree char *new_name = NULL;
           int res;
           if (!prefix)
             new_name = g_strconcat (self->id, extension, NULL);


### PR DESCRIPTION
Fixes 7a710f6cc5b6e27a5c0a0eff376bbaccfe46c097

```
In file included from /usr/include/glib-2.0/glib.h:117,
                 from /usr/include/glib-2.0/glib/gi18n.h:23,
                 from ../src/builder-manifest.c:31:
In function ‘g_autoptr_cleanup_generic_gfree’,
    inlined from ‘_rename_icon’ at ../src/builder-manifest.c:2346:28:
/usr/include/glib-2.0/glib/glib-autocleanups.h:32:3: warning: ‘new_name’ may be used uninitialized [-Wmaybe-uninitialized]
   32 |   g_free (*pp);
      |   ^~~~~~~~~~~~
../src/builder-manifest.c: In function ‘_rename_icon’:
../src/builder-manifest.c:2346:28: note: ‘new_name’ was declared here
 2346 |           g_autofree char *new_name;
      |                            ^~~~~~~~
```