### PR TITLE
builder-manifest: Override branch with --default-branch when specified

### DIFF
--- a/src/builder-manifest.c
+++ b/src/builder-manifest.c
@@ -1477,19 +1477,25 @@ builder_manifest_get_runtime_version (BuilderManifest *self)
   return self->runtime_version ? self->runtime_version : "master";
 }
 
+/* default-branch can only be set through the cli, where branch
+ * is extracted from the manifest. As such the intended behavior
+ * is that the cli arguments should always override the branch
+ * set in the manifest, so your manifest can set the branch
+ * but you are still able to do --default-branch=test-build
+ */
 const char *
 builder_manifest_get_branch (BuilderManifest *self,
                              BuilderContext  *context)
 {
-  if (self->branch)
-    return self->branch;
-
   if (context &&
       builder_context_get_default_branch (context))
     return builder_context_get_default_branch (context);
 
   if (self->default_branch)
     return self->default_branch;
+
+  if (self->branch)
+    return self->branch;
 
   return "master";
 }

--- a/tests/test-default-branch.json
+++ b/tests/test-default-branch.json
@@ -1,0 +1,26 @@
+{
+    "id": "org.test.DefaultBranch",
+    "runtime": "org.gnome.Platform",
+    "sdk": "org.gnome.Sdk",
+    "command": "hello",
+    "branch": "something",
+    "modules": [
+        {
+            "name": "install_test",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p ${FLATPAK_DEST}/bin",
+                "cp -vf hello.sh ${FLATPAK_DEST}/bin/hello"
+            ],
+            "sources": [
+                {
+                    "type": "script",
+                    "dest-filename": "hello.sh",
+                    "commands": [
+                        "echo \"Hello world, from a sandbox\""
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
builder-manifest: Override branch with --default-branch when specified

Commit 00f63cf added default-branch with the stated intention of being
able to override the branch specified in the manifest. The name is a bit
confusing.

However the scenario tested was only when there was no
specified branch at all, and thus the behavior was a bit buggy.

Till now, if you had both specified "branch": "something" in the
manifest and used --default-branch=test, the end result in the
ostree repo would be for flatpak-builder to use the branch name
specified in the manifest.

```
$ flatpak-builder --default-branch=test --force-clean --repo=_build/repo/ app/ tests/test-default-branch.json
$ ostree refs --repo=_build/repo/
app/org.test.DefaultBranch/x86_64/something
```

With this change, we properly pick up default-branch if its set,
since it can only be set through the cli and its the explicit intention
that we want to override it.

```
$ meson devenv -C _build/ flatpak-builder  --default-branch=test --user --force-clean --repo=repo_test/ app/ ../tests/test-default-branch.json
$ ostree refs --repo=_build/repo_test
app/org.test.DefaultBranch/x86_64/test
```

