### PR TITLE
builder-module: Default to builddir true for cmake and cmake-ninja

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,7 @@ TBD
 * Disable all filesystem access in flatpak-builder --run sandbox
 * Add ability to set custom fusermount path
 * Support setting state-dir for run
+* Default to builddir true for cmake and cmake-ninja buildsystems
 
 Changes in 1.4.6
 ================

--- a/doc/flatpak-manifest.xml
+++ b/doc/flatpak-manifest.xml
@@ -562,7 +562,7 @@
                     <term><option>builddir</option> (boolean)</term>
                     <listitem><para>Use a build directory that is separate from the source directory. This
                     defaults to <literal>true</literal> for the <option>meson</option> <option>buildsystem</option>
-                    since version 0.9.9.</para></listitem>
+                    since version 0.9.9 and since 1.5.0 for <option>cmake</option> and <option>cmake-ninja</option>.</para></listitem>
                 </varlistentry>
                 <varlistentry>
                     <term><option>subdir</option> (string)</term>

--- a/src/builder-module.c
+++ b/src/builder-module.c
@@ -1952,7 +1952,7 @@ builder_module_build_helper (BuilderModule   *self,
         }
 
       var_require_builddir = strstr (configure_content, "buildapi-variable-require-builddir") != NULL;
-      use_builddir = var_require_builddir || self->builddir || meson;
+      use_builddir = var_require_builddir || self->builddir || meson || cmake || cmake_ninja;
 
       if (use_builddir)
         {


### PR DESCRIPTION
Fixes #232 