### PR TITLE
builder-module: Record licence files in licences directory as well

### DIFF
--- a/src/builder-module.c
+++ b/src/builder-module.c
@@ -87,6 +87,18 @@ typedef struct {
   char *dst_name;
 } LicenseFile;
 
+typedef struct
+{
+  const char * const *patterns;
+  const char         *prefix;
+  GPtrArray          *files;
+} LicenseScanData;
+
+typedef gboolean (*LicenseScanCb) (int         fd,
+                                   const char *name,
+                                   gpointer    user_data,
+                                   GError    **error);
+
 static void serializable_iface_init (JsonSerializableIface *serializable_iface);
 
 G_DEFINE_TYPE_WITH_CODE (BuilderModule, builder_module, G_TYPE_OBJECT,
@@ -1611,6 +1623,109 @@ find_defined_license_files (GStrv       license_files,
   return TRUE;
 }
 
+static gboolean
+scan_license_dir (int              dirfd,
+                  LicenseScanCb    cb,
+                  gpointer         user_data,
+                  GError         **error)
+{
+  g_auto(GLnxDirFdIterator) dfd_iter = { 0, };
+  struct dirent *dent;
+  struct stat dir_st;
+
+  if (!glnx_dirfd_iterator_init_at (dirfd, ".", FALSE, &dfd_iter, error))
+    return FALSE;
+
+  if (fstat (dfd_iter.fd, &dir_st) < 0)
+    return glnx_throw_errno_prefix (error, "fstat dir");
+
+  while (TRUE)
+    {
+      if (!glnx_dirfd_iterator_next_dent_ensure_dtype (&dfd_iter, &dent, NULL, error))
+        return FALSE;
+
+      if (dent == NULL)
+        break;
+
+      glnx_autofd int opath_fd = -1;
+      glnx_autofd int fd = -1;
+      struct stat st;
+
+      opath_fd = openat (dfd_iter.fd, dent->d_name,
+                         O_PATH | O_NOFOLLOW | O_CLOEXEC);
+      if (opath_fd < 0)
+        {
+          if (G_IN_SET (errno, ENOENT, EACCES))
+            continue;
+          return glnx_throw_errno_prefix (error, "openat %s", dent->d_name);
+        }
+
+      if (fstat (opath_fd, &st) < 0)
+        return glnx_throw_errno_prefix (error, "fstat %s", dent->d_name);
+
+      if (dent->d_ino != 0 &&
+          (dent->d_ino != st.st_ino || st.st_dev != dir_st.st_dev))
+        continue;
+
+      if (!S_ISREG (st.st_mode))
+        continue;
+
+      fd = glnx_fd_reopen (opath_fd, O_RDONLY, error);
+      if (fd < 0)
+        return FALSE;
+
+      if (!cb (fd, dent->d_name, user_data, error))
+        return FALSE;
+    }
+
+  return TRUE;
+}
+
+static gboolean
+license_scan_cb (int         fd,
+                 const char *name,
+                 gpointer    user_data,
+                 GError    **error)
+{
+  LicenseScanData *data = user_data;
+  g_autofree char *src_path = NULL;
+  g_autofree char *dst_name = NULL;
+
+  if (data->patterns)
+    {
+      gboolean match = FALSE;
+
+      for (size_t i = 0; data->patterns[i] != NULL; i++)
+        {
+          if (g_str_has_prefix (name, data->patterns[i]))
+            {
+              match = TRUE;
+              break;
+            }
+        }
+
+      if (!match)
+        return TRUE;
+    }
+
+  if (data->prefix)
+    {
+      src_path = g_build_filename (data->prefix, name, NULL);
+      dst_name = g_strdup_printf ("%s_%s", data->prefix, name);
+    }
+  else
+    {
+      src_path = g_strdup (name);
+      dst_name = g_strdup (name);
+    }
+
+  return collect_license_file (fd,
+                               src_path,
+                               dst_name,
+                               data->files,
+                               error);
+}
+
 static const char *default_licence_file_patterns[] = {
   "COPYING",
   "COPYRIGHT",
@@ -1629,74 +1744,22 @@ find_default_license_files (BuilderModule  *self,
                             GError        **error)
 {
   glnx_autofd int source_dfd = -1;
-  g_auto(GLnxDirFdIterator) dfd_iter = { 0, };
-  struct dirent *dent;
-  struct stat dir_st;
+
+  LicenseScanData toplevel_data = {
+    .patterns = default_licence_file_patterns,
+    .prefix = NULL,
+    .files = files
+  };
 
   if (!glnx_opendirat (AT_FDCWD,
                        flatpak_file_get_path_cached (source_dir),
                        TRUE, &source_dfd, error))
     return FALSE;
 
-  if (!glnx_dirfd_iterator_init_at (source_dfd, ".", FALSE, &dfd_iter, error))
-    return FALSE;
-
-  if (fstat (dfd_iter.fd, &dir_st) < 0)
-    return glnx_throw_errno_prefix (error, "fstat dir");
-
-  while (TRUE)
-    {
-      if (!glnx_dirfd_iterator_next_dent_ensure_dtype (&dfd_iter, &dent, NULL, error))
-        return FALSE;
-
-      if (dent == NULL)
-        break;
-
-      for (size_t i = 0; default_licence_file_patterns[i] != NULL; i++)
-        {
-          if (!g_str_has_prefix (dent->d_name, default_licence_file_patterns[i]))
-            continue;
-
-          glnx_autofd int opath_fd = -1;
-          glnx_autofd int fd = -1;
-          struct stat st;
-
-          opath_fd = openat (dfd_iter.fd, dent->d_name,
-                             O_PATH | O_NOFOLLOW | O_CLOEXEC);
-          if (opath_fd < 0)
-            {
-              if (G_IN_SET (errno, ENOENT, EACCES))
-                continue;
-
-              return glnx_throw_errno_prefix (error, "openat %s", dent->d_name);
-            }
-
-          if (fstat (opath_fd, &st) < 0)
-            return glnx_throw_errno_prefix (error, "fstat %s", dent->d_name);
-
-          if (dent->d_ino != 0 &&
-              (dent->d_ino != st.st_ino || st.st_dev != dir_st.st_dev))
-            continue;
-
-          if (!S_ISREG (st.st_mode))
-            continue;
-
-          fd = glnx_fd_reopen (opath_fd, O_RDONLY, error);
-          if (fd < 0)
-            return FALSE;
-
-          if (!collect_license_file (fd,
-                                     dent->d_name,
-                                     dent->d_name,
-                                     files,
-                                     error))
-            return FALSE;
-
-          break;
-        }
-    }
-
-  return TRUE;
+  return scan_license_dir (source_dfd,
+                           license_scan_cb,
+                           &toplevel_data,
+                           error);
 }
 
 static gboolean

--- a/src/builder-module.c
+++ b/src/builder-module.c
@@ -1726,6 +1726,35 @@ license_scan_cb (int         fd,
                                error);
 }
 
+static gboolean
+scan_license_subdir (int               parent_dfd,
+                     const char       *subdir,
+                     LicenseScanData  *data,
+                     GError          **error)
+{
+  glnx_autofd int sub_dfd = -1;
+  g_autoptr(GError) local_error = NULL;
+
+  if (!glnx_opendirat (parent_dfd,
+                       subdir,
+                       FALSE,
+                       &sub_dfd,
+                       &local_error))
+    {
+      if (g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND) ||
+          g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NOT_DIRECTORY))
+        return TRUE;
+
+      g_propagate_error (error, g_steal_pointer (&local_error));
+      return FALSE;
+    }
+
+  return scan_license_dir (sub_dfd,
+                           license_scan_cb,
+                           data,
+                           error);
+}
+
 static const char *default_licence_file_patterns[] = {
   "COPYING",
   "COPYRIGHT",
@@ -1734,6 +1763,14 @@ static const char *default_licence_file_patterns[] = {
   "LICEN",
   "Licen",
   "licen",
+  NULL
+};
+
+static const char *license_dir_names[] = {
+  "LICENCES",
+  "LICENSES",
+  "licences",
+  "licenses",
   NULL
 };
 
@@ -1756,10 +1793,28 @@ find_default_license_files (BuilderModule  *self,
                        TRUE, &source_dfd, error))
     return FALSE;
 
-  return scan_license_dir (source_dfd,
-                           license_scan_cb,
-                           &toplevel_data,
-                           error);
+  if (!scan_license_dir (source_dfd,
+                         license_scan_cb,
+                         &toplevel_data,
+                         error))
+    return FALSE;
+
+  for (size_t i = 0; license_dir_names[i] != NULL; i++)
+    {
+      LicenseScanData subdir_data = {
+        .patterns = NULL,
+        .prefix = license_dir_names[i],
+        .files = files
+      };
+
+      if (!scan_license_subdir (source_dfd,
+                                license_dir_names[i],
+                                &subdir_data,
+                                error))
+        return FALSE;
+    }
+
+  return TRUE;
 }
 
 static gboolean

--- a/tests/test-builder-licence-paths.sh
+++ b/tests/test-builder-licence-paths.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 
 skip_without_fuse
 
-echo "1..4"
+echo "1..7"
 
 setup_repo
 install_repo
@@ -167,3 +167,95 @@ assert_file_has_content \
     '^MY DEFAULT LICENSE TEXT$'
 
 echo "ok license file is recorded by default"
+
+mkdir -p source_licence_5/LICENSES mkdir -p source_licence_5/licenses
+echo "MIT LICENSE TEXT" > source_licence_5/LICENSES/MIT.txt
+echo "APACHE LICENSE TEXT" > source_licence_5/licenses/Apache-2.0.txt
+tar czf source_licence_5.tar.gz source_licence_5/
+
+cat > test-license_subdir.json <<'EOF'
+{
+    "app-id": "org.test.licence_subdir",
+    "runtime": "org.test.Platform",
+    "sdk": "org.test.Sdk",
+    "modules": [{
+        "name": "test",
+        "buildsystem": "simple",
+        "build-commands": [],
+        "sources": [{
+            "type": "archive",
+            "path": "source_licence_5.tar.gz",
+            "dest-filename": "source_licence_5.tar.gz"
+        }]
+    }]
+}
+EOF
+
+run_build test-license_subdir.json
+
+assert_has_file appdir/files/share/licenses/org.test.licence_subdir/test/LICENSES_MIT.txt
+assert_file_has_content \
+    appdir/files/share/licenses/org.test.licence_subdir/test/LICENSES_MIT.txt \
+    '^MIT LICENSE TEXT$'
+assert_has_file appdir/files/share/licenses/org.test.licence_subdir/test/licenses_Apache-2.0.txt
+assert_file_has_content \
+    appdir/files/share/licenses/org.test.licence_subdir/test/licenses_Apache-2.0.txt \
+    '^APACHE LICENSE TEXT$'
+
+echo "ok licence subdir files are collected automatically"
+
+mkdir -p source_licence_6/LICENSES
+ln -s /etc/hostname source_licence_6/LICENSES/MIT.txt
+tar czf source_licence_6.tar.gz source_licence_6/
+
+cat > test-licence_subdir_symlink.json <<'EOF'
+{
+    "app-id": "org.test.licence_subdir_symlink",
+    "runtime": "org.test.Platform",
+    "sdk": "org.test.Sdk",
+    "modules": [{
+        "name": "test",
+        "buildsystem": "simple",
+        "build-commands": [],
+        "sources": [{
+            "type": "archive",
+            "path": "source_licence_6.tar.gz",
+            "dest-filename": "source_licence_6.tar.gz"
+        }]
+    }]
+}
+EOF
+
+run_build test-licence_subdir_symlink.json
+
+assert_not_has_file appdir/files/share/licenses/org.test.licence_subdir_symlink/test/LICENSES_MIT.txt
+
+echo "ok symlink inside licence subdir is skipped"
+
+mkdir -p source_licence_7
+ln -s /proc/self source_licence_7/LICENSES
+tar czf source_licence_7.tar.gz source_licence_7/
+
+cat > test-licence_subdir_itself_symlink.json <<'EOF'
+{
+    "app-id": "org.test.licence_subdir_itself_symlink",
+    "runtime": "org.test.Platform",
+    "sdk": "org.test.Sdk",
+    "modules": [{
+        "name": "test",
+        "buildsystem": "simple",
+        "build-commands": [],
+        "sources": [{
+            "type": "archive",
+            "path": "source_licence_7.tar.gz",
+            "dest-filename": "source_licence_7.tar.gz"
+        }]
+    }]
+}
+EOF
+
+run_build test-licence_subdir_itself_symlink.json
+
+assert_not_has_file appdir/files/share/licenses/org.test.licence_subdir_itself_symlink/test/LICENSES_environ
+
+echo "ok licence dir symlink is skipped"


### PR DESCRIPTION
The licences directory is a common convention across Qt and KDE
projects. See examples [1], [2], [3]. The files inside that directory
usually use the licence id as their filename. Listing them individually
inside licence-files key is annoying but without anything no licence
information is recorded for these projects. So when collecting the
default license files, also collect files inside the licences directory.

[1]: https://github.com/qt/qtbase/tree/2d790125429123aec4fb3dbee8335732f2d122eb/LICENSES
[2]: https://github.com/qt/qtwebengine/tree/cf5db2b9242facf4797a7779ae50916326f75d0b/LICENSES
[3]: https://invent.kde.org/system/dolphin/-/tree/02165defeeeb529a566c8cc00f30e7a5c8c11185/LICENSES