### PR TITLE
builder-module: Abort on invalid module names

### DIFF
--- a/src/builder-module.c
+++ b/src/builder-module.c
@@ -328,7 +328,7 @@ builder_module_set_property (GObject      *object,
       self->name = g_value_dup_string (value);
       if ((p = strchr (self->name, ' ')) ||
           (p = strchr (self->name, '/')))
-        g_printerr ("Module names like '%s' containing '%c' are problematic. Expect errors.\n", self->name, *p);
+        g_error ("Disallowed character '%c' in module name '%s'.\n", *p, self->name);
       break;
 
     case PROP_SUBDIR:


### PR DESCRIPTION
This goes a step above 6d1d9724c5b30c680e5eefe05f5ddf7b15fdc92e and makes it an actual error. The name is used to construct paths in various places