### PR TITLE
ci: Exercise -Werror in CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,7 +30,7 @@ jobs:
       CC: ${{ matrix.compiler }}
       BASE_CFLAGS: -Wp,-D_FORTIFY_SOURCE=2
       BUILDDIR: builddir
-      CONFIG_OPTS: -Dinstalled_tests=true
+      CONFIG_OPTS: -Denable_werror=true -Dinstalled_tests=true
 
     steps:
     - name: Check out flatpak-builder

--- a/meson.build
+++ b/meson.build
@@ -9,6 +9,10 @@ project(
 
 cc = meson.get_compiler('c')
 
+if get_option('enable_werror')
+  add_project_arguments('-Werror', language: 'c')
+endif
+
 project_c_args = [
   '-Werror=empty-body',
   '-Werror=strict-prototypes',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -28,3 +28,9 @@ option(
   description: 'system fusermount executable, or empty string to try multiple names (fusermount3, fusermount) automatically',
   value: '',
 )
+option(
+  'enable_werror',
+  type : 'boolean',
+  description : 'Treat warnings as errors for flatpak-builder',
+  value : false,
+)


### PR DESCRIPTION
Expose it via Meson arg as this needs to be scoped only to current project to be useful. libyaml has a bunch of warnings and is unmaintained so the wrap build fails with -Werror while 24.04 CI has too old OSTree without fixes which also fails due to -Werror.