### PR TITLE
main: pass --allow-custom to compose

### DIFF
--- a/src/builder-context.c
+++ b/src/builder-context.c
@@ -89,7 +89,8 @@ struct BuilderContext
 
   BuilderSdkConfig *sdk_config;
 
-  BuilderAsUrlPolicy as_url_policy;
+  BuilderAsUrlPolicy  as_url_policy;
+  char               *as_allow_custom;
 };
 
 typedef struct
@@ -130,6 +131,7 @@ builder_context_finalize (GObject *object)
   g_free (self->default_branch);
   g_free (self->state_subdir);
   g_free (self->stop_at);
+  g_free (self->as_allow_custom);
   g_strfreev (self->cleanup);
   g_strfreev (self->cleanup_platform);
   glnx_release_lock_file(&self->rofiles_file_lock);
@@ -376,6 +378,20 @@ const char *
 builder_context_get_opt_mirror_screenshots_url (BuilderContext *self)
 {
   return self->opt_mirror_screenshots_url;
+}
+
+void
+builder_context_set_as_allow_custom (BuilderContext *self,
+                                     const char *as_allow_custom)
+{
+  g_free (self->as_allow_custom);
+  self->as_allow_custom = g_strdup (as_allow_custom);
+}
+
+const char *
+builder_context_get_as_allow_custom (BuilderContext *self)
+{
+  return self->as_allow_custom;
 }
 
 GFile *

--- a/src/builder-context.h
+++ b/src/builder-context.h
@@ -185,6 +185,11 @@ void            builder_context_set_opt_mirror_screenshots_url (BuilderContext *
 
 const char *    builder_context_get_opt_mirror_screenshots_url (BuilderContext *self);
 
+void            builder_context_set_as_allow_custom (BuilderContext *self,
+                                                     const char *as_allow_custom);
+
+const char *    builder_context_get_as_allow_custom (BuilderContext *self);
+
 BuilderSdkConfig * builder_context_get_sdk_config (BuilderContext *self);
 
 gboolean        builder_context_create_state_dir (BuilderContext *self,

--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -90,6 +90,7 @@ static gboolean opt_log_system_bus;
 static gboolean opt_yes;
 static gint64 opt_source_date_epoch = -1;
 static gchar *opt_as_url_policy = NULL;
+static gchar *opt_as_allow_custom = NULL;
 
 static GOptionEntry entries[] = {
   { "verbose", 'v', 0, G_OPTION_ARG_NONE, &opt_verbose, "Print debug information during command processing", NULL },
@@ -146,6 +147,7 @@ static GOptionEntry entries[] = {
   { "no-shallow-clone", 0, 0, G_OPTION_ARG_NONE, &opt_no_shallow_clone, "Don't use shallow clones when mirroring git repos", NULL },
   { "override-source-date-epoch", 0, 0, G_OPTION_ARG_INT64, &opt_source_date_epoch, "Use this timestamp to perform the build, instead of the last modification time of the manifest.", NULL },
   { "compose-url-policy", 0, 0, G_OPTION_ARG_STRING, &opt_as_url_policy, "Set the AppStream compose URL policy to either 'partial' (default) or 'full'", "POLICY" },
+  { "compose-allow-custom", 0, 0, G_OPTION_ARG_STRING, &opt_as_allow_custom, "Set the AppStream compose custom keys that should be propagated to the output data.", "ENTRIES" },
   { NULL }
 };
 
@@ -615,6 +617,7 @@ main (int    argc,
   builder_context_set_bundle_sources (build_context, opt_bundle_sources);
   builder_context_set_opt_export_only (build_context, opt_export_only);
   builder_context_set_opt_mirror_screenshots_url (build_context, opt_mirror_screenshots_url);
+  builder_context_set_as_allow_custom (build_context, opt_as_allow_custom);
 
   if (opt_mirror_screenshots_url)
     {

--- a/src/builder-manifest.c
+++ b/src/builder-manifest.c
@@ -2424,6 +2424,7 @@ cmpstringp (const void *p1, const void *p2)
 static gboolean
 appstreamcli_compose (GError             **error,
                       BuilderAsUrlPolicy   as_url_policy,
+                      const char          *allow_custom,
                       ...)
 {
   g_autoptr(GPtrArray) args = NULL;
@@ -2437,7 +2438,10 @@ appstreamcli_compose (GError             **error,
   if (as_url_policy == BUILDER_AS_URL_POLICY_FULL)
     g_ptr_array_add (args, g_strdup ("--no-partial-urls"));
 
-  va_start (ap, as_url_policy);
+  if (allow_custom != NULL)
+    g_ptr_array_add (args, g_strdup_printf ("--allow-custom=%s", allow_custom));
+
+  va_start (ap, allow_custom);
   while ((arg = va_arg (ap, const gchar *)))
     g_ptr_array_add (args, g_strdup (arg));
   g_ptr_array_add (args, NULL);
@@ -3087,6 +3091,7 @@ builder_manifest_cleanup (BuilderManifest *self,
           const char *opt_mirror_screenshots_url = builder_context_get_opt_mirror_screenshots_url (context);
           gboolean opt_export_only = builder_context_get_opt_export_only (context);
           BuilderAsUrlPolicy as_url_policy = builder_context_get_as_url_policy (context);
+          const char *as_allow_custom = builder_context_get_as_allow_custom (context);
 
           if (opt_mirror_screenshots_url && !opt_export_only)
             {
@@ -3099,6 +3104,7 @@ builder_manifest_cleanup (BuilderManifest *self,
               g_print ("Saving screenshots in %s\n", flatpak_file_get_path_cached (media_dir));
               if (!appstreamcli_compose (error,
                                          as_url_policy,
+                                         as_allow_custom,
                                          "--prefix=/",
                                          origin,
                                          arg_base_url,
@@ -3116,6 +3122,7 @@ builder_manifest_cleanup (BuilderManifest *self,
               g_print ("Running appstreamcli compose\n");
               if (!appstreamcli_compose (error,
                                          as_url_policy,
+                                         as_allow_custom,
                                          "--prefix=/",
                                          origin,
                                          result_root_arg,


### PR DESCRIPTION
Add a CLI option to forward `--allow-custom` to appstreamcli compose. Store the setting in BuilderContext and plumb it through manifest cleanup.

Since https://github.com/ximion/appstream/commit/4d7bd4ac7295421b60b10ecdf1f501b22495ea66 the `--alow-custom` arg has been used to allow certain `<custom>` key-value pairs to make it through the compose process into the final metadata. By default, this value is set to none allowed.

In elementary AppCenter, we use custom metadata for things like allowing developers to set a suggested price for their app:
```
  <custom>
     <value key="x-appcenter-suggested-price">3</value>
  </custom>
```

Because we have no control over the `--allow-custom` arg during the `flatpak-builder` appstream compose, these tags are getting stripped from the final metdata. So, proposing adding this argument to allow controlling this in a `flatpak-builder` run.