### PR TITLE
ci: Use ubuntu 26.04 container & Exercise -Werror in CI 

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,6 +21,7 @@ jobs:
   check-meson:
     name: Ubuntu meson build
     runs-on: ${{ matrix.os }}
+    container: ubuntu:26.04
     strategy:
       matrix:
         os: ['ubuntu-24.04']
@@ -33,15 +34,22 @@ jobs:
       CONFIG_OPTS: -Dinstalled_tests=true
 
     steps:
+    - name: Install dependencies
+      run: |
+        apt-get update
+        apt-get install -y git findutils
+
+    - name: Set git safe directory
+      run: |
+        git config --global safe.directory "*"
+
     - name: Check out flatpak-builder
       # 6.0.2
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-    - name: Install Dependencies
+    - name: Install build dependencies
       run: |
-        sudo apt-get update
-        sudo apt-get install -y findutils
-        sudo apt-get install -y \
+        apt-get install -y \
           ${{ matrix.compiler }} \
           $(xargs < .github/dependencies.apt.txt)
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -51,6 +51,10 @@ jobs:
     - name: Build flatpak-builder with Meson
       run: meson compile -C ${BUILDDIR}
 
+    - name: Create dist tarball
+      run: |
+        meson dist --include-subprojects -C ${BUILDDIR}
+
     - name: Upload docs
       # 7.0.0
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -46,7 +46,7 @@ jobs:
           $(xargs < .github/dependencies.apt.txt)
 
     - name: Configure flatpak-builder
-      run: meson setup --wrap-mode nodownload ${CONFIG_OPTS} ${BUILDDIR} .
+      run: meson setup --wrap-mode nodownload ${CONFIG_OPTS} -Dwerror=true ${BUILDDIR} .
 
     - name: Build flatpak-builder with Meson
       run: meson compile -C ${BUILDDIR}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,20 +13,30 @@ jobs:
   release:
     name: Build and publish release
     runs-on: ubuntu-24.04
+    container: ubuntu:26.04
     permissions:
       contents: write
     steps:
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y git findutils
+
+      - name: Set git safe directory
+        run: |
+          git config --global safe.directory "*"
+
       - name: Checkout repository
         # 6.0.2
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 
-      - name: Install Dependencies
+      - name: Install build dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y findutils
-          sudo apt-get install -y \
+          apt-get update
+          apt-get install -y findutils
+          apt-get install -y \
             gcc \
             perl \
             jq \


### PR DESCRIPTION
Needed for new dependencies like appstream, GitHub is yet to make actions-images available for 26.04