### PR TITLE
builder-flatpak-utils: Fix const correctness warnings

### DIFF
--- a/src/builder-flatpak-utils.c
+++ b/src/builder-flatpak-utils.c
@@ -185,7 +185,7 @@ flatpak_path_match_prefix (const char *pattern,
           /* special case * at end */
           if (c == 0)
             {
-              char *tmp = strchr (string, '/');
+              const char *tmp = strchr (string, '/');
               if (tmp != NULL)
                 return tmp;
               return string + strlen (string);
@@ -1633,7 +1633,7 @@ get_xdg_user_dir_from_string (const char  *filesystem,
                               const char **suffix,
                               const char **dir)
 {
-  char *slash;
+  const char *slash;
   const char *rest;
   g_autofree char *prefix = NULL;
   gsize len;
@@ -2087,7 +2087,7 @@ option_add_generic_policy_cb (const gchar *option_name,
                               GError     **error)
 {
   FlatpakContext *context = data;
-  char *t;
+  const char *t;
   g_autofree char *key = NULL;
   const char *policy_value;
 
@@ -2114,7 +2114,7 @@ option_remove_generic_policy_cb (const gchar *option_name,
                                  GError     **error)
 {
   FlatpakContext *context = data;
-  char *t;
+  const char *t;
   g_autofree char *key = NULL;
   const char *policy_value;
   g_autofree char *extended_value = NULL;


### PR DESCRIPTION
Glibc 2.43 implements C23 const-preserving string-search functions [1]

This fixes the build with Glibc 2.43 and GCC 15.1 (which defaults to C23).

[1]: https://sourceware.org/glibc/wiki/Release/2.43#C23_Const-Preserving_Standard_Library_Macros_May_Break_Some_Packages

```
../src/builder-flatpak-utils.c:188:21: error: initializing 'char *' with an expression of type 'const char *' discards qualifiers [-Werror,-Wincompatible-pointer-types-discards-qualifiers]
  188 |               char *tmp = strchr (string, '/');
      |                     ^     ~~~~~~~~~~~~~~~~~~~~
../src/builder-flatpak-utils.c:1641:9: error: assigning to 'char *' from 'const char *' discards qualifiers [-Werror,-Wincompatible-pointer-types-discards-qualifiers]
 1641 |   slash = strchr (filesystem, '/');
      |         ^ ~~~~~~~~~~~~~~~~~~~~~~~~
../src/builder-flatpak-utils.c:2094:5: error: assigning to 'char *' from 'const char *' discards qualifiers [-Werror,-Wincompatible-pointer-types-discards-qualifiers]
 2094 |   t = strchr (value, '=');
      |     ^ ~~~~~~~~~~~~~~~~~~~
../src/builder-flatpak-utils.c:2122:5: error: assigning to 'char *' from 'const char *' discards qualifiers [-Werror,-Wincompatible-pointer-types-discards-qualifiers]
 2122 |   t = strchr (value, '=');
      |     ^ ~~~~~~~~~~~~~~~~~~~
1 warning and 4 errors generated.
```