### PR TITLE
build: Ignore typedef-redefinition when building with clang

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -37,6 +37,17 @@ foreach arg : project_c_args
   endif
 endforeach
 
+if cc.get_id() == 'clang'
+  clang_args = [
+    '-Wno-typedef-redefinition',
+  ]
+  foreach arg : clang_args
+    if cc.has_argument(arg)
+      add_project_arguments(arg, language: 'c')
+    endif
+  endforeach
+endif
+
 # The debugedit program is a hard dependency
 debugedit = find_program('debugedit', version: '>= 5.0')
 


### PR DESCRIPTION
OSTree has a typedef-redefinition in OstreeContentWriter, since it is allowed by C11 and earlier via GCC C11 extensions, ignore it for Clang builds