### PR TITLE
Fix some curl type issues

### DIFF
--- a/src/builder-flatpak-utils.c
+++ b/src/builder-flatpak-utils.c
@@ -1163,11 +1163,11 @@ flatpak_create_curl_session (const char *user_agent)
   if (curl_session == NULL)
     return NULL;
 
-  curl_easy_setopt (curl_session, CURLOPT_CONNECTTIMEOUT, 60);
-  curl_easy_setopt (curl_session, CURLOPT_FAILONERROR, 1);
-  curl_easy_setopt (curl_session, CURLOPT_FOLLOWLOCATION, 1);
-  curl_easy_setopt (curl_session, CURLOPT_MAXREDIRS, 50);
-  curl_easy_setopt (curl_session, CURLOPT_NOPROGRESS, 0);
+  curl_easy_setopt (curl_session, CURLOPT_CONNECTTIMEOUT, 60L);
+  curl_easy_setopt (curl_session, CURLOPT_FAILONERROR, 1L);
+  curl_easy_setopt (curl_session, CURLOPT_FOLLOWLOCATION, 1L);
+  curl_easy_setopt (curl_session, CURLOPT_MAXREDIRS, 50L);
+  curl_easy_setopt (curl_session, CURLOPT_NOPROGRESS, 0L);
   curl_easy_setopt (curl_session, CURLOPT_LOW_SPEED_TIME, 60L);
   curl_easy_setopt (curl_session, CURLOPT_LOW_SPEED_LIMIT, 10000L);
   curl_easy_setopt (curl_session, CURLOPT_USERAGENT, user_agent);

--- a/src/builder-utils.c
+++ b/src/builder-utils.c
@@ -1151,10 +1151,10 @@ typedef struct {
 } CURLWriteData;
 
 static gsize
-builder_curl_write_cb (gpointer *buffer,
+builder_curl_write_cb (char     *buffer,
                        gsize     size,
                        gsize     nmemb,
-                       gpointer *userdata)
+                       void     *userdata)
 {
   gsize bytes_written;
   CURLWriteData *write_data = (CURLWriteData *) userdata;


### PR DESCRIPTION
```

../src/builder-utils.c:1186:3: error: call to 'Wcurl_easy_setopt_err_write_callback' declared with 'warning' attribute: curl_easy_setopt expects a curl_write_callback argument [-Werror,-Wattribute-warning]
 1186 |   curl_easy_setopt (session, CURLOPT_WRITEFUNCTION, builder_curl_write_cb);
      |   ^
/usr/include/x86_64-linux-gnu/curl/typecheck-gcc.h:60:15: note: expanded from macro 'curl_easy_setopt'
   60 |               Wcurl_easy_setopt_err_write_callback();                   \
      |               ^
1 error generated.
```

```
../src/builder-flatpak-utils.c:1170:3: error: call to 'Wcurl_easy_setopt_err_long' declared with 'warning' attribute: curl_easy_setopt expects a long argument [-Werror,-Wattribute-warning]
 1170 |   curl_easy_setopt (curl_session, CURLOPT_NOPROGRESS, 0);
      |   ^
/usr/include/x86_64-linux-gnu/curl/typecheck-gcc.h:50:15: note: expanded from macro 'curl_easy_setopt'
   50 |               Wcurl_easy_setopt_err_long();                             \
      |               ^
../src/builder-flatpak-utils.c:1169:3: error: call to 'Wcurl_easy_setopt_err_long' declared with 'warning' attribute: curl_easy_setopt expects a long argument [-Werror,-Wattribute-warning]
 1169 |   curl_easy_setopt (curl_session, CURLOPT_MAXREDIRS, 50);
      |   ^
/usr/include/x86_64-linux-gnu/curl/typecheck-gcc.h:50:15: note: expanded from macro 'curl_easy_setopt'
   50 |               Wcurl_easy_setopt_err_long();                             \
      |               ^
../src/builder-flatpak-utils.c:1168:3: error: call to 'Wcurl_easy_setopt_err_long' declared with 'warning' attribute: curl_easy_setopt expects a long argument [-Werror,-Wattribute-warning]
 1168 |   curl_easy_setopt (curl_session, CURLOPT_FOLLOWLOCATION, 1);
      |   ^
/usr/include/x86_64-linux-gnu/curl/typecheck-gcc.h:50:15: note: expanded from macro 'curl_easy_setopt'
   50 |               Wcurl_easy_setopt_err_long();                             \
      |               ^
../src/builder-flatpak-utils.c:1167:3: error: call to 'Wcurl_easy_setopt_err_long' declared with 'warning' attribute: curl_easy_setopt expects a long argument [-Werror,-Wattribute-warning]
 1167 |   curl_easy_setopt (curl_session, CURLOPT_FAILONERROR, 1);
      |   ^
/usr/include/x86_64-linux-gnu/curl/typecheck-gcc.h:50:15: note: expanded from macro 'curl_easy_setopt'
   50 |               Wcurl_easy_setopt_err_long();                             \
      |               ^
../src/builder-flatpak-utils.c:1166:3: error: call to 'Wcurl_easy_setopt_err_long' declared with 'warning' attribute: curl_easy_setopt expects a long argument [-Werror,-Wattribute-warning]
 1166 |   curl_easy_setopt (curl_session, CURLOPT_CONNECTTIMEOUT, 60);
      |   ^
/usr/include/x86_64-linux-gnu/curl/typecheck-gcc.h:50:15: note: expanded from macro 'curl_easy_setopt'
   50 |               Wcurl_easy_setopt_err_long();                             \
      |               ^
5 errors generated.
```