### PR TITLE
builder-main: Enable ccache by default if it exists in SDK

### DIFF
--- a/doc/flatpak-builder.xml
+++ b/doc/flatpak-builder.xml
@@ -367,8 +367,20 @@
                 <term><option>--ccache</option></term>
 
                 <listitem><para>
-                     Enable use of ccache in the build (needs ccache in the sdk). The default ccache folder can be
-                     overridden by setting the environment variable CCACHE_DIR.
+                     This option is deprecated since 1.5.0 and kept for compatibility
+                     as ccache is enabled by default if it exists in the SDK.
+                </para></listitem>
+            </varlistentry>
+
+            <varlistentry>
+                <term><option>--no-ccache</option></term>
+
+                <listitem><para>
+                     Disable use of ccache in the build.
+
+                     ccache is enabled by default if it exists in the
+                     SDK. The default ccache folder can be overridden by
+                     setting the CCACHE_DIR environment variable.
                 </para></listitem>
             </varlistentry>
 

--- a/src/builder-context.c
+++ b/src/builder-context.c
@@ -1224,6 +1224,38 @@ builder_context_get_sdk_config (BuilderContext *self)
 }
 
 gboolean
+builder_context_ccache_available_in_sdk (BuilderContext *self,
+                                         const char     *sdk_path)
+{
+  static const char ccache_path[] = "files/bin/ccache";
+
+  glnx_autofd int root_dfd = -1;
+  glnx_autofd int fd = -1;
+  struct stat st;
+
+  if (!glnx_opendirat (AT_FDCWD, sdk_path, TRUE, &root_dfd, NULL))
+    return FALSE;
+
+  fd = glnx_chaseat (root_dfd,
+                     ccache_path,
+                     GLNX_CHASE_RESOLVE_BENEATH |
+                     GLNX_CHASE_MUST_BE_REGULAR,
+                     NULL);
+  if (fd < 0)
+    return FALSE;
+
+  if (fstat (fd, &st) < 0)
+    return FALSE;
+
+  if ((st.st_mode & (S_IXUSR | S_IXGRP | S_IXOTH)) == 0)
+    return FALSE;
+
+  g_print ("Found ccache at %s/%s\n", sdk_path, ccache_path);
+
+  return TRUE;
+}
+
+gboolean
 builder_context_create_state_dir (BuilderContext *self,
                                   GError        **error)
 {

--- a/src/builder-context.h
+++ b/src/builder-context.h
@@ -187,6 +187,9 @@ const char *    builder_context_get_opt_mirror_screenshots_url (BuilderContext *
 
 BuilderSdkConfig * builder_context_get_sdk_config (BuilderContext *self);
 
+gboolean builder_context_ccache_available_in_sdk (BuilderContext *self,
+                                                  const char     *sdk_path);
+
 gboolean        builder_context_create_state_dir (BuilderContext *self,
                                                   GError        **error);
 

--- a/src/builder-main.c
+++ b/src/builder-main.c
@@ -51,7 +51,8 @@ static gboolean opt_show_deps;
 static gboolean opt_show_manifest;
 static gboolean opt_disable_download;
 static gboolean opt_disable_updates;
-static gboolean opt_ccache;
+static gboolean opt_ccache; /* deprecated, kept for compat */
+static gboolean opt_no_ccache;
 static gboolean opt_require_changes;
 static gboolean opt_keep_build_dirs;
 static gboolean opt_delete_build_dirs;
@@ -99,7 +100,8 @@ static GOptionEntry entries[] = {
   { "add-tag", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_add_tags, "Add a tag to the build", "TAG"},
   { "remove-tag", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_remove_tags, "Remove a tag from the build", "TAG"},
   { "run", 0, 0, G_OPTION_ARG_NONE, &opt_run, "Run a command in the build directory (see --run --help)", NULL },
-  { "ccache", 0, 0, G_OPTION_ARG_NONE, &opt_ccache, "Use ccache", NULL },
+  { "ccache", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_ccache, "Use ccache (deprecated as it is auto-enabled when available in SDK)", NULL },
+  { "no-ccache", 0, 0, G_OPTION_ARG_NONE, &opt_no_ccache, "Disable ccache use", NULL },
   { "disable-cache", 0, 0, G_OPTION_ARG_NONE, &opt_disable_cache, "Disable cache lookups", NULL },
   { "disable-tests", 0, 0, G_OPTION_ARG_NONE, &opt_disable_tests, "Don't run tests", NULL },
   { "disable-rofiles-fuse", 0, 0, G_OPTION_ARG_NONE, &opt_disable_rofiles, "Disable rofiles-fuse use", NULL },
@@ -155,7 +157,8 @@ static GOptionEntry run_entries[] = {
   { "run", 0, 0, G_OPTION_ARG_NONE, &opt_run, "Run a command in the build directory", NULL },
   { "log-session-bus", 0, 0, G_OPTION_ARG_NONE, &opt_log_session_bus, N_("Log session bus calls"), NULL },
   { "log-system-bus", 0, 0, G_OPTION_ARG_NONE, &opt_log_system_bus, N_("Log system bus calls"), NULL },
-  { "ccache", 0, 0, G_OPTION_ARG_NONE, &opt_ccache, "Use ccache", NULL },
+  { "ccache", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_ccache, "Use ccache (deprecated as it is auto-enabled when available in SDK)", NULL },
+  { "no-ccache", 0, 0, G_OPTION_ARG_NONE, &opt_no_ccache, "Disable ccache use", NULL },
   { "state-dir", 0, 0, G_OPTION_ARG_FILENAME, &opt_state_dir, "Use this directory for state instead of .flatpak-builder", "PATH" },
   { NULL }
 };
@@ -688,12 +691,6 @@ main (int    argc,
       builder_context_set_stop_at (build_context, opt_stop_at);
     }
 
-  if (!builder_context_set_enable_ccache (build_context, opt_ccache, &error))
-    {
-      g_printerr ("Can't initialize ccache use: %s\n", error->message);
-      return 1;
-  }
-
   if (opt_from_git)
     {
       g_autofree char *manifest_dirname = g_path_get_dirname (manifest_rel_path);
@@ -948,6 +945,25 @@ main (int    argc,
     {
       g_printerr ("Failed to init: %s\n", error->message);
       return 1;
+    }
+
+  if (!opt_no_ccache)
+    {
+      gboolean want_ccache = FALSE;
+      const char *sdk_path = builder_manifest_get_sdk_path (manifest);
+
+      if (sdk_path != NULL)
+        want_ccache = builder_context_ccache_available_in_sdk (build_context, sdk_path);
+
+      if (!want_ccache && opt_ccache)
+        g_printerr ("Warning: --ccache passed but ccache not found in SDK, ignoring\n");
+
+      if (want_ccache &&
+          !builder_context_set_enable_ccache (build_context, TRUE, &error))
+        {
+          g_printerr ("Can't initialize ccache use: %s\n", error->message);
+          return 1;
+        }
     }
 
   if (!opt_finish_only &&

--- a/src/builder-manifest.c
+++ b/src/builder-manifest.c
@@ -73,6 +73,7 @@ struct BuilderManifest
   char           *runtime_version;
   char           *sdk;
   char           *sdk_commit;
+  char           *sdk_path;
   char           *var;
   char           *base;
   char           *base_commit;
@@ -196,6 +197,7 @@ builder_manifest_finalize (GObject *object)
   g_free (self->runtime_version);
   g_free (self->sdk);
   g_free (self->sdk_commit);
+  g_free (self->sdk_path);
   g_free (self->base);
   g_free (self->base_commit);
   g_free (self->base_version);
@@ -1482,6 +1484,12 @@ builder_manifest_get_runtime_version (BuilderManifest *self)
 }
 
 const char *
+builder_manifest_get_sdk_path (BuilderManifest *self)
+{
+  return self->sdk_path;
+}
+
+const char *
 builder_manifest_get_branch (BuilderManifest *self,
                              BuilderContext  *context)
 {
@@ -1691,7 +1699,6 @@ builder_manifest_start (BuilderManifest *self,
 {
   g_autofree char *arch_option = NULL;
   g_autoptr(GHashTable) names = g_hash_table_new (g_str_hash, g_str_equal);
-  g_autofree char *sdk_path = NULL;
   const char *stop_at;
 
   self->source_date_epoch = builder_context_get_source_date_epoch (context);
@@ -1718,9 +1725,10 @@ builder_manifest_start (BuilderManifest *self,
              builder_manifest_get_runtime_version (self),
              self->sdk_commit);
 
-  sdk_path = flatpak_info_show_path (self->sdk, builder_manifest_get_runtime_version (self), context);
-  if (sdk_path != NULL &&
-      !builder_context_load_sdk_config (context, sdk_path, error))
+  g_clear_pointer (&self->sdk_path, g_free);
+  self->sdk_path = flatpak_info_show_path (self->sdk, builder_manifest_get_runtime_version (self), context);
+  if (self->sdk_path != NULL &&
+      !builder_context_load_sdk_config (context, self->sdk_path, error))
     return FALSE;
 
   self->runtime_commit = flatpak (NULL, "info", arch_option, "--show-commit", self->runtime,

--- a/src/builder-manifest.h
+++ b/src/builder-manifest.h
@@ -57,6 +57,7 @@ char *          builder_manifest_get_debug_id (BuilderManifest *self);
 char *          builder_manifest_get_sources_id (BuilderManifest *self);
 const char *    builder_manifest_get_id_platform (BuilderManifest *self);
 char *          builder_manifest_get_locale_id_platform (BuilderManifest *self);
+const char *    builder_manifest_get_sdk_path (BuilderManifest *self);
 BuilderOptions *builder_manifest_get_build_options (BuilderManifest *self);
 GList *         builder_manifest_get_modules (BuilderManifest *self);
 GList *         builder_manifest_get_add_extensions (BuilderManifest *self);


### PR DESCRIPTION
The old `--ccache` argument is deprecated and replaced by a `--no-ccache` argument. It will be removed in some future unstable versions.

Now it is enabled by default if `ccache` exists in SDK or `--ccache` is explicitly passed while disabled if it does not exist or `--no-ccache` is explicitly passed.

In the first case, this also improves the previous behaviour and prevents blindly creating dangling symlinks when `ccache` does not actually exist in the SDK but someone passed `--ccache` anyway.

See: https://github.com/flatpak/flatpak-builder/issues/743
Fixes: https://github.com/flatpak/flatpak-builder/issues/582