### PR TITLE
ci: Set persist-credentials to false in checkout step

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -46,6 +46,8 @@ jobs:
     - name: Check out flatpak-builder
       # 6.0.2
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      with:
+        persist-credentials: false
 
     - name: Install build dependencies
       run: |


### PR DESCRIPTION
It's a no-op since permissions is already set to read but satisfies zizmor