### PR TITLE
ci: Drop BASE_CFLAGS

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,7 +29,6 @@ jobs:
 
     env:
       CC: ${{ matrix.compiler }}
-      BASE_CFLAGS: -Wp,-D_FORTIFY_SOURCE=2
       BUILDDIR: builddir
       CONFIG_OPTS: -Dinstalled_tests=true
 


### PR DESCRIPTION
    BASE_CFLAGS was leftover from autotools [1], we forgot to drop it
    in [2]. Oops!
    
    _FORTIFY_SOURCE=2 is set via distro's GCC in the 26.04 container
    so we do not need to define it again and doing so causes
    a redefinition warning.
    
    [1]: https://github.com/flatpak/flatpak-builder/commit/fe8a52d5e8814289a0b3f248c4b5d3c06e5b8343#diff-0462e381b2fb3286568215681c8983490a37ac9ae0f0c5ee304df7fa6426d4afL46
    [2]: https://github.com/flatpak/flatpak-builder/pull/691
