### PR TITLE
tests: Wire LSAN suppressions to meson

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -82,7 +82,6 @@ jobs:
         ASAN_OPTIONS: "detect_leaks=1:fast_unwind_on_malloc=0:malloc_context_size=20:symbolize=1"
         UBSAN_OPTIONS: "print_stacktrace=1"
       run: |
-        export LSAN_OPTIONS="suppressions=$GITHUB_WORKSPACE/tests/lsan.supp"
         timeout --signal=KILL -v ${TESTS_TIMEOUT}m meson test -C ${BUILDDIR} --verbose --timeout-multiplier ${MESON_TEST_TIMEOUT_MULTIPLIER}
 
     - name: Upload test logs

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -8,6 +8,14 @@ test_env.set('G_TEST_BUILDDIR', meson.current_build_dir())
 test_env.prepend('PATH', meson.current_build_dir() / '..' / 'src', separator: ':')
 test_env.set('FUSERMOUNT', fusermount_program.full_path())
 
+if get_option('b_sanitize').contains('address')
+  test_env.prepend(
+    'LSAN_OPTIONS',
+    'suppressions=' + meson.current_source_dir() / 'lsan.supp',
+    separator: ':'
+  )
+endif
+
 test_names = [
   'test-builder',
   'test-builder-deprecated',


### PR DESCRIPTION
Otherwise it is annoying to manually export this every time I want to run tests locally