### PR TITLE
tests: Centralise flatpak-builder helpers in libtest

### DIFF
--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -314,6 +314,37 @@ run_sh () {
     ${CMD_PREFIX} flatpak run --command=bash ${ARGS-} org.test.Hello -c "$*"
 }
 
+: "${FORCE_CLEAN:=1}"
+
+builder_run_app () {
+    local appdir="${APPDIR:-appdir}"
+
+    ${FLATPAK_BUILDER} --run "$appdir" "$@"
+}
+
+_run_build () {
+    local appdir="${APPDIR:-appdir}"
+
+    if [ -n "${BUILD_LOG:-}" ]; then
+        ${FLATPAK_BUILDER} ${FORCE_CLEAN:+--force-clean} \
+            "$appdir" "$@" >&2 2>"$BUILD_LOG"
+    else
+        ${FLATPAK_BUILDER} ${FORCE_CLEAN:+--force-clean} \
+            "$appdir" "$@" >&2
+    fi
+}
+
+run_build () {
+    _run_build "$@"
+}
+
+run_build_fail () {
+    if _run_build "$@"; then
+        echo "build of ${!#} unexpectedly succeeded" >&2
+        exit 1
+    fi
+}
+
 # fuse support is needed (and the kernel module needs to be loaded) for several
 # flatpak-builder tests
 skip_without_fuse () {

--- a/tests/test-builder-cleanup.sh
+++ b/tests/test-builder-cleanup.sh
@@ -32,11 +32,6 @@ install_sdk_repo
 
 cd "$TEST_DATA_DIR"
 
-run_build () {
-    local manifest=$1
-    ${FLATPAK_BUILDER} --force-clean appdir "$manifest" >&2
-}
-
 cat > test-cleanup-toplevel.json <<'EOF'
 {
   "app-id": "org.test.CleanupToplevel",

--- a/tests/test-builder-deprecated.sh
+++ b/tests/test-builder-deprecated.sh
@@ -42,49 +42,49 @@ cp "$srcdir"/org.test.Deprecated.SHA1.file.yaml .
 cp "$srcdir"/hello.sh .
 cp "$srcdir"/hello.tar.xz .
 
-${FLATPAK_BUILDER} --force-clean appdir org.test.Deprecated.MD5.archive.json >&2 2> build-error-log
+BUILD_LOG=build-error-log run_build org.test.Deprecated.MD5.archive.json
 assert_file_has_content build-error-log 'The "md5" source property is deprecated due to the weakness of MD5 hashes.'
 assert_file_has_content build-error-log 'Use the "sha256" property for the more secure SHA256 hash.'
 
 echo "ok deprecated MD5 hash for archive in JSON"
 
-${FLATPAK_BUILDER} --force-clean appdir org.test.Deprecated.MD5.archive.yaml >&2 2> build-error-log
+BUILD_LOG=build-error-log run_build org.test.Deprecated.MD5.archive.yaml
 assert_file_has_content build-error-log 'The "md5" source property is deprecated due to the weakness of MD5 hashes.'
 assert_file_has_content build-error-log 'Use the "sha256" property for the more secure SHA256 hash.'
 
 echo "ok deprecated MD5 hash for archive in YAML"
 
-${FLATPAK_BUILDER} --force-clean appdir org.test.Deprecated.MD5.file.json >&2 2> build-error-log
+BUILD_LOG=build-error-log run_build org.test.Deprecated.MD5.file.json
 assert_file_has_content build-error-log 'The "md5" source property is deprecated due to the weakness of MD5 hashes.'
 assert_file_has_content build-error-log 'Use the "sha256" property for the more secure SHA256 hash.'
 
 echo "ok deprecated MD5 hash for file in JSON"
 
-${FLATPAK_BUILDER} --force-clean appdir org.test.Deprecated.MD5.file.yaml >&2 2> build-error-log
+BUILD_LOG=build-error-log run_build org.test.Deprecated.MD5.file.yaml
 assert_file_has_content build-error-log 'The "md5" source property is deprecated due to the weakness of MD5 hashes.'
 assert_file_has_content build-error-log 'Use the "sha256" property for the more secure SHA256 hash.'
 
 echo "ok deprecated MD5 hash for file in YAML"
 
-${FLATPAK_BUILDER} --force-clean appdir org.test.Deprecated.SHA1.archive.json >&2 2> build-error-log
+BUILD_LOG=build-error-log run_build org.test.Deprecated.SHA1.archive.json
 assert_file_has_content build-error-log 'The "sha1" source property is deprecated due to the weakness of SHA1 hashes.'
 assert_file_has_content build-error-log 'Use the "sha256" property for the more secure SHA256 hash.'
 
 echo "ok deprecated SHA1 hash for archive in JSON"
 
-${FLATPAK_BUILDER} --force-clean appdir org.test.Deprecated.SHA1.archive.yaml >&2 2> build-error-log
+BUILD_LOG=build-error-log run_build org.test.Deprecated.SHA1.archive.yaml
 assert_file_has_content build-error-log 'The "sha1" source property is deprecated due to the weakness of SHA1 hashes.'
 assert_file_has_content build-error-log 'Use the "sha256" property for the more secure SHA256 hash.'
 
 echo "ok deprecated SHA1 hash for archive in YAML"
 
-${FLATPAK_BUILDER} --force-clean appdir org.test.Deprecated.SHA1.file.json >&2 2> build-error-log
+BUILD_LOG=build-error-log run_build org.test.Deprecated.SHA1.file.json
 assert_file_has_content build-error-log 'The "sha1" source property is deprecated due to the weakness of SHA1 hashes.'
 assert_file_has_content build-error-log 'Use the "sha256" property for the more secure SHA256 hash.'
 
 echo "ok deprecated SHA1 hash for file in JSON"
 
-${FLATPAK_BUILDER} --force-clean appdir org.test.Deprecated.SHA1.file.yaml >&2 2> build-error-log
+BUILD_LOG=build-error-log run_build org.test.Deprecated.SHA1.file.yaml
 assert_file_has_content build-error-log 'The "sha1" source property is deprecated due to the weakness of SHA1 hashes.'
 assert_file_has_content build-error-log 'Use the "sha256" property for the more secure SHA256 hash.'
 

--- a/tests/test-builder-flags.sh
+++ b/tests/test-builder-flags.sh
@@ -32,11 +32,6 @@ install_sdk_repo
 
 cd "$TEST_DATA_DIR"
 
-run_build () {
-    local manifest=$1
-    ${FLATPAK_BUILDER} --force-clean appdir "$manifest" >&2
-}
-
 # Default: CGO_CFLAGS=$CFLAGS (inherited from SDK or set explicitly)
 # The test SDK does not ship with defaults so it is set here
 # via cflags explicitly.

--- a/tests/test-builder-licence-paths.sh
+++ b/tests/test-builder-licence-paths.sh
@@ -34,19 +34,6 @@ cd "$TEST_DATA_DIR"
 
 REPO="$(pwd)/repos/test"
 
-run_build () {
-    local manifest=$1
-    ${FLATPAK_BUILDER} --force-clean appdir "$manifest" >&2
-}
-
-run_build_fail () {
-    local manifest=$1
-    if ${FLATPAK_BUILDER} --force-clean appdir "$manifest" >&2; then
-        echo "build of $manifest unexpectedly succeeded" >&2
-        exit 1
-    fi
-}
-
 mkdir -p source_licence_1
 ln -s /proc/self source_licence_1/licenses
 tar czf source_licence_1.tar.gz source_licence_1/

--- a/tests/test-builder-python.sh
+++ b/tests/test-builder-python.sh
@@ -42,22 +42,23 @@ cp -a $(dirname $0)/testpython.py .
 cp $(dirname $0)/importme.py .
 cp $(dirname $0)/importme2.py .
 chmod u+w *.py
-flatpak-builder --force-clean appdir org.test.Python.json >&2
+
+run_build org.test.Python.json
 
 assert_has_file appdir/files/bin/importme.pyc
 
-flatpak-builder --run appdir org.test.Python.json testpython.py > testpython.out
+builder_run_app org.test.Python.json testpython.py > testpython.out
 
 assert_file_has_content testpython.out ^modified$
 
 echo "ok handled pyc rewriting multiple times"
 
-flatpak-builder --force-clean appdir org.test.Python2.json >&2
+run_build org.test.Python2.json
 
 assert_not_has_file appdir/files/bin/importme.py
 assert_has_file appdir/files/bin/importme.pyc
 
-flatpak-builder --run appdir org.test.Python2.json testpython.py > testpython.out
+builder_run_app org.test.Python2.json testpython.py > testpython.out
 
 assert_file_has_content testpython.out "^first   $"
 

--- a/tests/test-builder-src-date-epoch.sh
+++ b/tests/test-builder-src-date-epoch.sh
@@ -32,11 +32,6 @@ install_sdk_repo
 
 cd "$TEST_DATA_DIR"
 
-run_build () {
-    local manifest=$1
-    ${FLATPAK_BUILDER} --force-clean appdir "$manifest" >&2
-}
-
 cat > test-src-date-epoch-default.json <<'EOF'
 {
     "app-id": "org.test.src_date_epoch_default",
@@ -73,7 +68,7 @@ cat > test-src-date-epoch-override.json <<'EOF'
 }
 EOF
 
-${FLATPAK_BUILDER} --force-clean --override-source-date-epoch=1234567890 appdir test-src-date-epoch-override.json >&2
+run_build --override-source-date-epoch=1234567890 test-src-date-epoch-override.json
 
 assert_file_has_content appdir/files/sde_out '^1234567890$'
 
@@ -94,7 +89,7 @@ cat > test-src-date-epoch-disable.json <<'EOF'
 }
 EOF
 
-${FLATPAK_BUILDER} --force-clean --override-source-date-epoch=0 appdir test-src-date-epoch-disable.json >&2
+run_build --override-source-date-epoch=0 test-src-date-epoch-disable.json
 
 assert_file_has_content appdir/files/sde_out '^unset$'
 

--- a/tests/test-builder.sh
+++ b/tests/test-builder.sh
@@ -74,7 +74,8 @@ echo "MY LICENSE" > ./LICENSE
 
 for MANIFEST in test.json test.yaml test-rename.json test-rename-appdata.json ; do
     echo "building manifest $MANIFEST" >&2
-    ${FLATPAK_BUILDER} --repo=$REPO $FL_GPGARGS --force-clean appdir $MANIFEST >&2
+
+    run_build --repo="$REPO" $FL_GPGARGS "$MANIFEST"
 
     assert_file_has_content appdir/files/share/app-data version1
     assert_file_has_content appdir/metadata shared=network;
@@ -121,9 +122,9 @@ assert_file_has_content app_data_1 version1
 echo "ok install+run"
 
 echo "version2" > app-data
-${FLATPAK_BUILDER} $FL_GPGARGS --repo=$REPO --force-clean appdir test.json >&2
+run_build $FL_GPGARGS --repo="$REPO" test.json
 assert_file_has_content appdir/files/share/app-data version2
-${FLATPAK_BUILDER} $FL_GPGARGS --repo=$REPO --force-clean appdir test.yaml >&2
+run_build $FL_GPGARGS --repo="$REPO" test.yaml
 assert_file_has_content appdir/files/share/app-data version2
 
 ${FLATPAK} ${U} update -y org.test.Hello2 master >&2
@@ -135,13 +136,11 @@ echo "ok update"
 
 # The build-args of --help should prevent the faulty cleanup and
 # platform-cleanup commands from executing
-${FLATPAK_BUILDER} $FL_GPGARGS --repo=$REPO --force-clean runtimedir \
-    test-runtime.json >&2
+APPDIR=runtimedir run_build $FL_GPGARGS --repo="$REPO" test-runtime.json
 
 echo "ok runtime build cleanup with build-args"
 
-${FLATPAK_BUILDER} $FL_GPGARGS --repo=$REPO --force-clean runtimedir \
-    test-runtime-platform.json >&2
+APPDIR=runtimedir run_build $FL_GPGARGS --repo="$REPO" test-runtime-platform.json
 
 BUILD_GROUP_COUNT=$(grep -c '^\[Build\]' runtimedir/metadata.platform)
 if [ "$BUILD_GROUP_COUNT" -gt 1 ]; then
@@ -158,9 +157,11 @@ fi
 echo "ok no duplicate [Build] groups in platform metadata"
 
 # test screenshot ref commit
-${FLATPAK_BUILDER} --repo=$REPO/repo_sc --force-clean builddir_sc \
+APPDIR=builddir_sc \
+run_build \
+    --repo="$REPO/repo_sc" \
     --mirror-screenshots-url=https://example.org/media \
-    org.flatpak_builder.gui.json >&2
+    org.flatpak_builder.gui.json
 ostree --repo=$REPO/repo_sc refs|grep -Eq "^screenshots/$(flatpak --default-arch)$"
 ostree checkout --repo=$REPO/repo_sc -U screenshots/$(flatpak --default-arch) outdir_sc
 find outdir_sc -path "*/icons/64x64/org.test.Hello.png" -type f | grep -q .
@@ -168,11 +169,12 @@ find outdir_sc -path "*/icons/64x64/org.test.Hello.png" -type f | grep -q .
 echo "ok screenshot ref commit"
 
 # test compose partial url policy
-${FLATPAK_BUILDER} --force-clean builddir_sc \
+APPDIR=builddir_sc \
+run_build \
     --mirror-screenshots-url=https://example.org/media \
     --state-dir .fp-compose-url-policy-partial \
     --compose-url-policy=partial \
-    org.flatpak.appstream_media.json >&2
+    org.flatpak.appstream_media.json
 # we test for the icon tag instead of screenshot
 # the former works offline the latter does not
 gzip -cdq builddir_sc/files/share/app-info/xmls/org.flatpak.appstream_media.xml.gz|grep -Eq '>org/flatpak/appstream_media/[^/]+/icons/128x128/org.flatpak.appstream_media.png</icon>'
@@ -181,11 +183,12 @@ echo "ok compose partial url policy"
 
 # test compose full url policy
 if appstream_has_version 0 16 3; then
-    ${FLATPAK_BUILDER} --force-clean builddir_sc \
+    APPDIR=builddir_sc \
+    run_build \
         --mirror-screenshots-url=https://example.org/media \
         --state-dir .fp-compose-url-policy-full \
         --compose-url-policy=full \
-        org.flatpak.appstream_media.json >&2
+        org.flatpak.appstream_media.json
 
     gzip -cdq builddir_sc/files/share/app-info/xmls/org.flatpak.appstream_media.xml.gz|grep -Eq '>https://example.org/media/org/flatpak/appstream_media/[^/]+/icons/128x128/org.flatpak.appstream_media.png</icon>'
 
@@ -195,8 +198,8 @@ else
 fi
 
 # test install
-${FLATPAK_BUILDER} --user --install \
-    --force-clean builddir org.flatpak.install_test.json >&2
+APPDIR=builddir run_build --user --install org.flatpak.install_test.json
+
 REFS=$(flatpak list --all --columns=ref 2>/dev/null)
 echo "$REFS" | grep -q "org\.flatpak\.install_test"
 echo "$REFS" | grep -q "org\.flatpak\.install_test\.Debug"
@@ -204,7 +207,7 @@ echo "$REFS" | grep -q "org\.flatpak\.install_test\.Locale"
 
 echo "ok install"
 
-${FLATPAK_BUILDER} --repo=$REPO --force-clean appdir test-locale-cleanup.json >&2
+run_build --repo="$REPO" test-locale-cleanup.json
 
 assert_not_has_file appdir/files/share/runtime/locale/es/share/es/testA.mo
 assert_has_file appdir/files/share/runtime/locale/es/share/es/testB.mo


### PR DESCRIPTION
Noticed I started repeating it in a bunch of tests and some of the old tests were not using the correct `${FLATPAK_BUILDER}` variable